### PR TITLE
MNT use py3.8 for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
 python:
-  version: "3.10"
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,3 @@
 python:
-  version: "3.8"
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
RDT seems to have 3.8 as the latest supported python.