### PR TITLE
CI add codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+comment: false
+codecov:
+  branch: main
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 9
+    wait_for_ci: true


### PR DESCRIPTION
This should disable codecov PR comments and make it wait for the CI to pass before failing.