### PR TITLE
CI cancel old jobs if a new commit comes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,6 +4,10 @@ on:
   - push
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
 


### PR DESCRIPTION
This makes the older jobs to get cancelled when a new commit comes in a PR or a branch.