### PR TITLE
MNT Bump Hub version to 0.8.1 for upload_folder

### DIFF
--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -11,7 +11,7 @@ PYTEST_MIN_VERSION = "5.0.1"
 #     "tomli": ("1.1.0", "install", "python_full_version < '3.11.0a7'"),
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
-    "huggingface_hub": ("0.5", "install", None),
+    "huggingface_hub": ("0.8.1", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),
     "pytest-cov": ("2.9.0", "tests", None),
     "flake8": ("3.8.2", "tests", None),


### PR DESCRIPTION
Bumping Hub dependency to 0.8.1 to prevent below error. (on my local I always had latest one so didn't come across this)
<img width="1023" alt="Ekran Resmi 2022-06-30 16 14 34" src="https://user-images.githubusercontent.com/53175384/176688676-5e97a6b2-be77-4fa2-a0c9-35f4b694e61c.png">

