### PR TITLE
MNT mark tests requiring internet

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,6 +55,21 @@ Using conda
 You can also replace the above `mamba` commands with `conda` if you don't have
 `mamba` installed.
 
+
+Running Tests
+~~~~~~~~~~~~~
+
+Certain tests require internet access to run, and they typically take slightly
+longer to run than other tests. If you'd like to skip those tests, you can add
+`-m not network` to your `pytest` command, or `-m network` to only run those
+tests. For example, you can run all tests except the ones requiring internet
+with:
+
+.. code:: bash
+
+   pytest -m "not network"
+
+
 Releases
 ========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ filterwarnings = [
     "error::FutureWarning",
 ]
 markers = [
-    "network: marks tests as requiring internet (deselect with '-m \"not slow\"')",
+    "network: marks tests as requiring internet (deselect with '-m \"not network\"')",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ filterwarnings = [
     "error::DeprecationWarning",
     "error::FutureWarning",
 ]
+markers = [
+    "network: marks tests as requiring internet (deselect with '-m \"not slow\"')",
+]

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -131,6 +131,7 @@ def test_init(model_pickle, config_json):
         )
 
 
+@pytest.mark.network
 @pytest.mark.parametrize("explicit_create", [True, False])
 def test_push_download(
     explicit_create, repo_path, destination_path, model_pickle, config_json


### PR DESCRIPTION
Marking the test which requires internet, and is much slower than others.

Fixes #43 

cc @skops-dev/maintainers 