### PR TITLE
Add mypy check to CI and fix existing mypy errors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,6 +56,9 @@ jobs:
       run: |
         python -m pytest -s --cov=skops --doctest-modules skops/
 
+    - name: Mypy
+      run: mypy --strict skops
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ filterwarnings = [
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",
 ]
+
+[tool.mypy]
+exclude = "(\\w+/)*test_\\w+\\.py$"
+ignore_missing_imports = true

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -17,6 +17,7 @@ dependent_packages = {
     "pytest-cov": ("2.9.0", "tests", None),
     "flake8": ("3.8.2", "tests", None),
     "mypy": ("0.770", "tests", None),
+    "types-requests": ("2.28.5", "tests", None),
     "flaky": ("3.7.0", "tests", None),
     "sphinx": ("3.2.0", "docs", None),
     "sphinx-gallery": ("0.7.0", "docs", None),
@@ -29,7 +30,7 @@ dependent_packages = {
 
 
 # create inverse mapping for setuptools
-tag_to_packages: dict = {
+tag_to_packages: dict[str, list[str]] = {
     extra: []
     for extra in ["build", "install", "docs", "examples", "tests", "benchmark"]
 }

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -1,4 +1,6 @@
 """All minimum dependencies for scikit-learn."""
+from __future__ import annotations
+
 import argparse
 
 PYTEST_MIN_VERSION = "5.0.1"

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 import copy
 import re
 import shutil
+import sys
 import tempfile
 from pathlib import Path
-from typing import Any, Protocol, Union
+from typing import Any, Union
 
 from modelcards import CardData, ModelCard
 from sklearn.utils import estimator_html_repr
 
 import skops
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 
 class SklearnBaseEstimator(Protocol):

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import re
 import shutil

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -10,7 +10,7 @@ PYTHON_VERSION = sys.version_info
 
 try:
     # py>=3.8
-    from importlib import metadata  # noqa
+    from importlib import metadata  # type: ignore  # noqa
 except ImportError:
     # older pythons
     import importlib_metadata as metadata  # type: ignore  # noqa
@@ -43,7 +43,7 @@ def path_unlink(path: Path, missing_ok: bool = False) -> None:
         return
 
     if PYTHON_VERSION >= (3, 8):
-        path.unlink(missing_ok=missing_ok)
+        path.unlink(missing_ok=missing_ok)  # type: ignore  # silence mypy for Py 3.7
         return
 
     # for Python 3.7, just catch the error

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -8,12 +8,10 @@ from pathlib import Path
 PYTHON_VERSION = sys.version_info
 
 
-try:
-    # py>=3.8
-    from importlib import metadata  # type: ignore  # noqa
-except ImportError:
-    # older pythons
-    import importlib_metadata as metadata  # type: ignore  # noqa
+if PYTHON_VERSION >= (3, 8):
+    from importlib import metadata  # noqa
+else:
+    import importlib_metadata as metadata  # noqa
 
 
 def path_unlink(path: Path, missing_ok: bool = False) -> None:

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -5,9 +5,6 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 
-PYTHON_VERSION = sys.version_info
-
-
 if sys.version_info >= (3, 8):
     from importlib import metadata  # noqa
 else:
@@ -40,8 +37,8 @@ def path_unlink(path: Path, missing_ok: bool = False) -> None:
         path.unlink()
         return
 
-    if PYTHON_VERSION >= (3, 8):
-        path.unlink(missing_ok=missing_ok)  # type: ignore  # silence mypy for Py 3.7
+    if sys.version_info >= (3, 8):
+        path.unlink(missing_ok=missing_ok)
         return
 
     # for Python 3.7, just catch the error

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -8,7 +8,7 @@ from pathlib import Path
 PYTHON_VERSION = sys.version_info
 
 
-if PYTHON_VERSION >= (3, 8):
+if sys.version_info >= (3, 8):
     from importlib import metadata  # noqa
 else:
     import importlib_metadata as metadata  # noqa

--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -13,10 +13,10 @@ try:
     from importlib import metadata  # noqa
 except ImportError:
     # older pythons
-    import importlib_metadata as metadata  # noqa
+    import importlib_metadata as metadata  # type: ignore  # noqa
 
 
-def path_unlink(path: Path, missing_ok=False) -> None:
+def path_unlink(path: Path, missing_ok: bool = False) -> None:
     """Remove this file or symbolic link
 
     Parameters


### PR DESCRIPTION
I created this PR and, at the suggestion of Adrin, #62, to evaluate whether we want to use mypy and if yes, how.

In this PR, mypy is used in strict mode and as can be seen, it does require a few workarounds to make it pass. Most notably, we have:

```python
class SklearnBaseEstimator(Protocol):
    def get_params(self, deep: bool = True) -> dict[str, Any]:
        ...
```

is needed (and conveniently, CI complains that `...` was not covered by tests) since sklearn is not typed.

```python
class _SklearnConfig(TypedDict):
    environment: list[str]

class ConfigJson(TypedDict):
    sklearn: _SklearnConfig | None
```

to represent the `config.json` (of course, `TypedDict` doesn't exist in Python 3.7).

```python
    def recursively_default_dict():  # type: ignore
        return collections.defaultdict(recursively_default_dict)
```

a recursive data structure not based on a type, ugh.

Moreover, there are still lot's of `Any`s, 

On the other hand, the non-strict PR shows that mypy let's us slip a bunch of untyped functions and methods, which decreases our confidence on how much we can rely on the type checker to help us out (e.g. when refactoring code).

Between strict and non-strict, there is of course a spectrum using the available mypy settings to silence specific types of errors.

Another question is whether we want to add mypy to the pre-commit hooks. It would work well for now but mypy tends to get slow when the code base gets large. The daemon could help, I don't know how big of a difference it makes and how convenient it is to use.

My personal opinion is that I'm pretty meh on the value mypy brings currently. But of course, the larger the code base will become, the more potential it has to uncover hidden errors and guide in refactoring. Editor type hints are not so important for me personally.

ping @merveenoyan @adrinjalali 

PS: I'll take a look at the failing codecov once we decide how to proceed.