### PR TITLE
MNT ignore _min_dependencies.py in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,5 @@ codecov:
   notify:
     after_n_builds: 12
     wait_for_ci: true
+ignore:
+  - "skops/_min_dependencies.py"  # This file is not tested, and won't be.


### PR DESCRIPTION
We don't test the file, and don't intend to, it just gives us warnings since it's not tested.