### PR TITLE
TST Add coverage report to pytest runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ filterwarnings = [
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",
 ]
+addopts = "--cov=skops --cov-report=term-missing"
+
+[tool.coverage.run]
+omit = [
+    "skops/**/test_*.py",
+    "skops/_min_dependencies.py",
+]
 
 [tool.mypy]
 exclude = "(\\w+/)*test_\\w+\\.py$"


### PR DESCRIPTION
Running pytest now gives an output like this:

```
---------- coverage: platform linux, python 3.10.5-final-0 -----------
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
skops/__init__.py                     8      1    88%   31
skops/card/__init__.py                2      0   100%
skops/card/_model_card.py            52      0   100%
skops/hub_utils/__init__.py           2      0   100%
skops/hub_utils/_hf_hub.py           98     21    79%   92-94, 125-127, 310, 356-365, 463-473
skops/hub_utils/tests/common.py       1      0   100%
skops/utils/fixes.py                 18      4    78%   13, 22, 56-57
---------------------------------------------------------------
TOTAL                               181     26    86%
```