### PR TITLE
ENH Card class: add repr and str methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ profile = "black"
 filterwarnings = [
     "error::DeprecationWarning",
     "error::FutureWarning",
-    "ignore::sklearn.exceptions.ConvergenceWarning",
 ]
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ profile = "black"
 filterwarnings = [
     "error::DeprecationWarning",
     "error::FutureWarning",
+    "ignore::sklearn.exceptions.ConvergenceWarning",
 ]
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ filterwarnings = [
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",
 ]
+addopts = "--cov=skops --cov-report=term-missing"
+
+[tool.coverage.run]
+omit = [
+    "skops/**/test_*.py",
+    "skops/_min_dependencies.py",
+]
 
 [tool.mypy]
 exclude = "(\\w+/)*test_\\w+\\.py$"

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from reprlib import aRepr
+from reprlib import Repr
 from typing import Any
 
 from modelcards import CardData, ModelCard
@@ -13,7 +13,8 @@ from sklearn.utils import estimator_html_repr
 
 import skops
 
-# aRepr attributes can be used to control the behavior of repr
+# Repr attributes can be used to control the behavior of repr
+aRepr = Repr()
 aRepr.maxother = 79
 aRepr.maxstring = 79
 

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -5,12 +5,17 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
+from reprlib import aRepr
 from typing import Any
 
 from modelcards import CardData, ModelCard
 from sklearn.utils import estimator_html_repr
 
 import skops
+
+# aRepr attributes can be used to control the behavior of repr
+aRepr.maxother = 79
+aRepr.maxstring = 79
 
 
 class Card:
@@ -195,3 +200,44 @@ class Card:
         for hyperparameter, value in hyperparameter_dict.items():
             table += f"| {hyperparameter} | {value} |\n"
         return table
+
+    @staticmethod
+    def _strip_blank(text) -> str:
+        # remove new lines and multiple spaces
+        text = text.replace("\n", " ")
+        text = re.sub(r"\s+", r" ", text)
+        return text
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        # create repr for model
+        model = getattr(self, "model", None)
+        if model:
+            model_str = self._strip_blank(repr(model))
+            model_repr = aRepr.repr(f"  model={model_str},").strip('"').strip("'")
+        else:
+            model_repr = None
+
+        template_reprs = []
+        for key, val in self.template_sections.items():
+            val = self._strip_blank(repr(val))
+            template_reprs.append(aRepr.repr(f"  {key}={val},").strip('"').strip("'"))
+        template_repr = "\n".join(template_reprs)
+
+        figure_reprs = []
+        for key, val in self._figure_paths.items():
+            val = self._strip_blank(repr(val))
+            figure_reprs.append(aRepr.repr(f"  {key}={val},").strip('"').strip("'"))
+        figure_repr = "\n".join(figure_reprs)
+
+        complete_repr = "Card(\n"
+        if model_repr:
+            complete_repr += model_repr + "\n"
+        if template_repr:
+            complete_repr += template_repr + "\n"
+        if figure_repr:
+            complete_repr += figure_repr + "\n"
+        complete_repr += ")"
+        return complete_repr

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -48,8 +48,11 @@ class Card:
     >>> X, y = load_iris(return_X_y=True)
     >>> model = LogisticRegression(random_state=0).fit(X, y)
     >>> model_card = card.Card(model)
-    >>> model_card.add(license="mit")  # doctest: +ELLIPSIS
-    <skops.card._model_card.Card object at ...>
+    >>> model_card.add(license="mit")
+    Card(
+      model=LogisticRegression(random_state=0),
+      license='mit',
+    )
     >>> y_pred = model.predict(X)
     >>> cm = confusion_matrix(y, y_pred,labels=model.classes_)
     >>> disp = ConfusionMatrixDisplay(confusion_matrix=cm,
@@ -59,7 +62,11 @@ class Card:
     >>> disp.figure_.savefig("confusion_matrix.png")
     ...
     >>> model_card.add_plot(confusion_matrix="confusion_matrix.png") # doctest: +ELLIPSIS
-    <skops.card._model_card.Card object at ...>
+    Card(
+      model=LogisticRegression(random_state=0),
+      license='mit',
+      confusion_matrix='confusion_matrix.png',
+    )
     >>> model_card.save((Path("save_dir") / "README.md")) # doctest: +ELLIPSIS
     ...
     """

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -107,3 +107,120 @@ def test_metadata_keys(destination_path, model_card):
     model_card.save(Path(destination_path) / "README.md")
     with open(Path(destination_path) / "README.md", "r") as f:
         assert "tags: dummy" in f.read()
+
+
+class TestCardRepr:
+    """Test __str__ and __repr__ methods of Card, which are identical for now"""
+
+    @pytest.fixture
+    def card(self):
+        model = LinearRegression(fit_intercept=False)
+        card = Card(model=model)
+        card.add(
+            model_description="A description",
+            model_card_authors="Jane Doe",
+        )
+        card.add_plot(
+            roc_curve="ROC_curve.png",
+            confusion_matrix="confusion_matrix.jpg",
+        )
+        return card
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_card_repr(self, card: Card, meth):
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model=LinearRegression(fit_intercept=False),\n"
+            "  model_description='A description',\n"
+            "  model_card_authors='Jane Doe',\n"
+            "  roc_curve='ROC_curve.png',\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_very_long_lines_are_shortened(self, card: Card, meth):
+        card.add(my_section="very long line " * 100)
+        result = meth(card)
+        expected = (
+            "Card(\n  model=LinearRegression(fit_intercept=False),\n"
+            "  model_description='A description',\n  model_card_authors='Jane Doe',\n"
+            "  my_section='very long line very lon...line very long line very long line"
+            " ',\n"
+            "  roc_curve='ROC_curve.png',\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_without_model_attribute(self, card: Card, meth):
+        del card.model
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model_description='A description',\n"
+            "  model_card_authors='Jane Doe',\n"
+            "  roc_curve='ROC_curve.png',\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_no_template_sections(self, card: Card, meth):
+        card.template_sections = {}
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model=LinearRegression(fit_intercept=False),\n"
+            "  roc_curve='ROC_curve.png',\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_no_figures(self, card: Card, meth):
+        card._figure_paths = {}
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model=LinearRegression(fit_intercept=False),\n"
+            "  model_description='A description',\n"
+            "  model_card_authors='Jane Doe',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_template_section_val_not_str(self, card: Card, meth):
+        card.template_sections["model_description"] = [1, 2, 3]  # type: ignore
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model=LinearRegression(fit_intercept=False),\n"
+            "  model_description=[1, 2, 3],\n"
+            "  model_card_authors='Jane Doe',\n"
+            "  roc_curve='ROC_curve.png',\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("meth", [repr, str])
+    def test_figure_path_val_not_str(self, card: Card, meth):
+        card._figure_paths["roc_curve"] = {1: 2}  # type: ignore
+        result = meth(card)
+        expected = (
+            "Card(\n"
+            "  model=LinearRegression(fit_intercept=False),\n"
+            "  model_description='A description',\n"
+            "  model_card_authors='Jane Doe',\n"
+            "  roc_curve={1: 2},\n"
+            "  confusion_matrix='confusion_matrix.jpg',\n"
+            ")"
+        )
+        assert result == expected


### PR DESCRIPTION
Solves #59

We decided not to follow the `eval(repr(card)) == card` convention, as it wouldn't work here.