### PR TITLE
ENH populate model card metadata with info from config.json

### DIFF
--- a/examples/plot_hf_hub.py
+++ b/examples/plot_hf_hub.py
@@ -92,7 +92,11 @@ print(os.listdir(local_repo))
 # ==========
 # We will now create a model card and save it. For more information about how
 # to create a good model card, refer to the :ref:`model card example
-# <sphx_glr_auto_examples_plot_model_card.py>`
+# <sphx_glr_auto_examples_plot_model_card.py>`. The following code uses
+# :func:`~skops.card.metadata_from_config` which creates a minimal metadata
+# object to be included in the metadata section of the model card. The
+# configuration used by this method is stored in the ``config.json`` file which
+# is created by the call to :func:`~skops.hub_utils.init`.
 model_card = card.Card(model, metadata=card.metadata_from_config(Path(local_repo)))
 model_card.save(Path(local_repo) / "README.md")
 

--- a/examples/plot_hf_hub.py
+++ b/examples/plot_hf_hub.py
@@ -90,8 +90,10 @@ print(os.listdir(local_repo))
 # %%
 # Model Card
 # ==========
-# We will now create a model card and save it
-model_card = card.Card(model)
+# We will now create a model card and save it. For more information about how
+# to create a good model card, refer to the :ref:`model card example
+# <sphx_glr_auto_examples_plot_model_card.py>`
+model_card = card.Card(model, metadata=card.metadata_from_config(Path(local_repo)))
 model_card.save(Path(local_repo) / "README.md")
 
 # %%

--- a/examples/plot_hf_hub.py
+++ b/examples/plot_hf_hub.py
@@ -109,6 +109,7 @@ token = os.environ["HF_HUB_TOKEN"]
 repo_name = f"hf_hub_example-{uuid4()}"
 user_name = HfApi().whoami(token=token)["name"]
 repo_id = f"{user_name}/{repo_name}"
+print(f"Creating and pushing to repo: {repo_id}")
 
 # Now we can push our files to the repo. The following function creates the
 # remote repository if it doesn't exist; this is controlled via the

--- a/examples/plot_model_card.py
+++ b/examples/plot_model_card.py
@@ -79,11 +79,12 @@ hub_utils.init(
 # %%
 # Create a model card
 # ====================
-# We now create a model card.
-# Then, we pass information using ``add()`` and plots using ``add_plot()``.
-# We'll then save the card as `README.md`.
+# We now create a model card, and populate its metadata with information which
+# is already provided in ``config.json``, which itself is created by the call
+# to ``init`` above. Then, we pass information using ``add()`` and plots using
+# ``add_plot()``. We'll then save the card as `README.md`.
 
-model_card = card.Card(model)
+model_card = card.Card(model, metadata=card.metadata_from_config(Path(local_repo)))
 
 
 # %%
@@ -94,7 +95,7 @@ model_card = card.Card(model)
 # have to have a section in our template.
 # We will save the plots, and then pass plot name with path to ``add_inspection``.
 
-license = "mit"
+model_card.metadata.license = "mit"
 limitations = "This model is not ready to be used in production."
 model_description = (
     "This is a HistGradientBoostingClassifier model trained on breast cancer dataset."

--- a/skops/card/__init__.py
+++ b/skops/card/__init__.py
@@ -1,3 +1,3 @@
-from ._model_card import Card
+from ._model_card import Card, metadata_from_config
 
-__all__ = ["Card"]
+__all__ = ["Card", "metadata_from_config"]

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from modelcards import CardData, ModelCard
 from sklearn.utils import estimator_html_repr
@@ -40,7 +40,7 @@ def metadata_from_config(config_path: Union[str, Path]) -> CardData:
 
     Returns
     -------
-    card_data: ``CardData``
+    card_data: ``modelcards.CardData``
         ``CardData`` object.
     """
     config_path = Path(config_path)
@@ -139,7 +139,10 @@ class Card:
     """
 
     def __init__(
-        self, model: Any, model_diagram: bool = True, metadata: CardData = None
+        self,
+        model: Any,
+        model_diagram: bool = True,
+        metadata: Optional[CardData] = None,
     ) -> None:
         self.model = model
         self._hyperparameter_table = self._extract_estimator_config()

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -140,7 +140,6 @@ class Card:
     >>> model_card.add_plot(confusion_matrix="confusion_matrix.png") # doctest: +ELLIPSIS
     Card(
       model=LogisticRegression(random_state=0),
-      license='mit',
       confusion_matrix='confusion_matrix.png',
     )
     >>> with tempfile.TemporaryDirectory() as tmpdir:

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -58,8 +58,12 @@ def metadata_from_config(config_path: Union[str, Path]) -> CardData:
         card_data.tags += [task]
 
     example_input = config.get("sklearn", {}).get("example_input", None)
+    # Documentation on what the widget expects:
+    # https://huggingface.co/docs/hub/models-widgets-examples
     if example_input:
-        card_data.widget = {"structuredData": example_input}
+        if "tabular" in task:
+            card_data.widget = {"structuredData": example_input}
+        # TODO: add text data example here.
 
     return card_data
 

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -68,9 +68,9 @@ def test_add(destination_path, model_card):
 
 
 def test_template_sections_not_mutated_by_save(destination_path, model_card):
-    template_sections_before = copy.deepcopy(model_card.template_sections)
+    template_sections_before = copy.deepcopy(model_card._template_sections)
     model_card.save(Path(destination_path) / "README.md")
-    template_sections_after = copy.deepcopy(model_card.template_sections)
+    template_sections_after = copy.deepcopy(model_card._template_sections)
     assert template_sections_before == template_sections_after
 
 
@@ -103,7 +103,7 @@ def test_temporary_plot(destination_path, model_card):
 
 def test_metadata_keys(destination_path, model_card):
     # test if the metadata is added on top of the card
-    model_card.add(tags="dummy")
+    model_card.metadata.tags = "dummy"
     model_card.save(Path(destination_path) / "README.md")
     with open(Path(destination_path) / "README.md", "r") as f:
         assert "tags: dummy" in f.read()


### PR DESCRIPTION
This PR adds a convenience function to populate the metadata section of model cards from the info available in `config.json`.

I'll be adding tests, but I'm wondering what you think of the API @merveenoyan @BenjaminBossan ?