### PR TITLE
Minor improvement to the getting started code

### DIFF
--- a/examples/plot_model_card.py
+++ b/examples/plot_model_card.py
@@ -104,7 +104,7 @@ model_description = (
 )
 model_card_authors = "skops_user"
 get_started_code = (
-    "import pickle\nwith open(dtc_pkl_filename, 'rb') as file:\nclf = pickle.load(file)"
+    "import pickle\nwith open(pkl_filename, 'rb') as file:\n    clf = pickle.load(file)"
 )
 citation_bibtex = "bibtex\n@inproceedings{...,year={2020}}"
 model_card.add(

--- a/skops/card/default_template.md
+++ b/skops/card/default_template.md
@@ -36,9 +36,8 @@ Use the code below to get started with the model.
 <details>
 <summary> Click to expand </summary>
 
-```
+```python
 {{ get_started_code | default("[More Information Needed]", true)}}
-
 ```
 
 </details>


### PR DESCRIPTION
- Add missing indentation inside `with` block
- Mark code as Python code for highlighting
- Rename variable name from `dtc_pkl_filename` to `pkl_filename`. The
  name itself doesn't really matter, as it's not assigned anywhere, but
  I found `dtc` confusing here ('decision tree classifier'?).