### PR TITLE
DOC Add installation instruction to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@ Installation
 
 You can install this library using:
 
-    pip install skops
+.. code-block:: sh
+
+    python -m pip install skops
 
 Bug Reports and Questions
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Installation
 
 You can install this library using:
 
-.. code-block:: sh
+.. code-block:: bash
 
     python -m pip install skops
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ User Guide / API Reference
 .. toctree::
    :maxdepth: 2
 
+   installation
    hf_hub
    model_card
    modules/classes

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,14 @@
+.. _installation:
+
+Installation
+============
+
+To install skops, run the following command in your Python environment:
+
+.. code-block:: bash
+
+    python -m pip install skops
+
+If you're interested in contributing to skops, please follow the `contribution
+guideline <https://github.com/skops-dev/skops/blob/main/CONTRIBUTING.rst>`__
+instead.


### PR DESCRIPTION
I think the docs should have an installation instruction. Thus I added a new section there but LMK if I should put it elsewhere instead @skops-dev/maintainers 