### PR TITLE
Fix wrong link to logo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
     :target: https://github.com/psf/black
     :alt: Black
 
-.. image:: https://raw.githubusercontent.com/skops-dev/skops/main/doc/images/logo.png
+.. image:: https://raw.githubusercontent.com/skops-dev/skops/main/docs/images/logo.png
   :target: https://skops.readthedocs.io/en/latest/
 
 SKOPS

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@
     :alt: Black
 
 .. image:: https://raw.githubusercontent.com/skops-dev/skops/main/docs/images/logo.png
+  :width: 500
   :target: https://skops.readthedocs.io/en/latest/
 
 SKOPS


### PR DESCRIPTION
Solves #92

I found the logo to be too big by default, set the width to 500.