### PR TITLE
DOC Add intersphinx linking to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,10 +40,11 @@ extensions = [
     "numpydoc",
     "sphinx_gallery.gen_gallery",
     "sphinx_issues",
+    "sphinx.ext.intersphinx",  # link to other documentations, e.g. sklearn
 ]
 
 autodoc_default_options = {"members": True, "inherited-members": True}
-autodoc_typehints = "description"
+autodoc_typehints = "none"
 
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to your example scripts
@@ -79,4 +80,15 @@ html_static_path = ["_static"]
 html_logo = "images/logo.png"
 html_theme_options = {
     "logo_only": True,
+}
+
+# See:
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
+    "huggingface_hub": ("https://huggingface.co/docs/huggingface_hub/main/en", None),
 }

--- a/docs/hf_hub.rst
+++ b/docs/hf_hub.rst
@@ -22,7 +22,7 @@ have on the Hub:
 - ``config.json``: contains the configuration needed to run the model.
 - The persisted model file. There are no constraints on the name of the file
   and the name is configured in ``config.json``. The file needs to be loadable
-  by ``joblib`` or ``pickle``.
+  by :func:`joblib.load` or :func:`pickle.load`.
 
 There are certain requirements in terms of information about the model for the
 Hub to be able to load and run the model. For scikit-learn compatible models,

--- a/docs/model_card.rst
+++ b/docs/model_card.rst
@@ -52,7 +52,7 @@ template which includes the following slots for free text sections:
   domains if relevant.
 - ``"get_started_code"``: Code the user can run to load and use the model.
 - ``"model_card_authors"``: Authors of the model card. This section includes
-  authors of the model card, while ``citation_bibtex`` includes citations
+  authors of the model card, while ``"citation_bibtex"`` includes citations
   related to the model if relevant.
 - ``"model_card_contact"``: Contact information of people whom can be reached
   out, in case of questions about the model or the model card.

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -95,7 +95,7 @@ def metadata_from_config(config_path: Union[str, Path]) -> CardData:
 
     This method populates the following attributes of the instance:
 
-    - ``library_name``: It needs to be ``sklearn`` for scikit-learn
+    - ``library_name``: It needs to be ``"sklearn"`` for scikit-learn
         compatible models.
     - ``tags``: Set to a list, containing ``"sklearn"`` and the task of the
         model. You can then add more tags to this list.
@@ -206,7 +206,6 @@ class Card:
       model=LogisticRegression(random_state=0),
       metadata.license=mit,
     )
-
     >>> cm = confusion_matrix(y, y_pred,labels=model.classes_)
     >>> disp = ConfusionMatrixDisplay(
     ...     confusion_matrix=cm,
@@ -290,12 +289,13 @@ class Card:
 
         Add a table to the model card. This can be especially useful when you
         using cross validation with sklearn. E.g. you can directly pass the
-        result from calling ``cross_validate`` or the ``cv_results_`` attribute
-        from any of the hyperparameter searches, such as ``GridSearchCV``.
+        result from calling :func:`sklearn.model_selection.cross_validate` or
+        the ``cv_results_`` attribute from any of the hyperparameter searches,
+        such as :class:`sklearn.model_selection.GridSearchCV`.
 
-        Morevoer, you can pass any pandas ``DataFrame`` to this method and it
-        will be rendered in the model card. You may consider selecting only a
-        part of the table if it's too big:
+        Morevoer, you can pass any pandas :class:`pandas.DataFrame` to this
+        method and it will be rendered in the model card. You may consider
+        selecting only a part of the table if it's too big:
 
         .. code:: python
 
@@ -314,8 +314,8 @@ class Card:
             headers, and the values should be tables. Tables can be either dicts
             with the key being strings that represent the column name, and the
             values being lists that represent the entries for each row.
-            Alternatively, the table can be a pandas ``DataFrame``. The table
-            must not be empty.
+            Alternatively, the table can be a :class:`pandas.DataFrame`. The
+            table must not be empty.
 
         Returns
         -------
@@ -354,7 +354,7 @@ class Card:
         Parameters
         ----------
         path: str, or Path
-            filepath to save your card.
+            Filepath to save your card.
 
         Notes
         -----
@@ -406,6 +406,7 @@ class Card:
 
     def _extract_estimator_config(self) -> str:
         """Extracts estimator hyperparameters and renders them into a vertical table.
+
         Returns
         -------
         str:

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -41,6 +41,11 @@ def _validate_folder(path: Union[str, Path]) -> None:
     path: str or Path
         The location of the repo.
 
+    Raises
+    ------
+    TypeError
+        Raised when the passed path is invalid.
+
     Returns
     -------
     None
@@ -82,7 +87,7 @@ def _get_example_input(data):
     Returns
     -------
     example_input: dict of lists
-        The example input of the model as accepted by HuggingFace's backend.
+        The example input of the model as accepted by Hugging Face's backend.
     """
     try:
         import pandas as pd
@@ -147,7 +152,7 @@ def _create_config(
     ],
     data,
 ) -> None:
-    """Write the configuration into a `config.json` file.
+    """Write the configuration into a ``config.json`` file.
 
     Parameters
     ----------
@@ -223,7 +228,7 @@ def init(
 ) -> None:
     """Initialize a scikit-learn based Hugging Face repo.
 
-    Given a model pickle and a set of required packages, this function
+    Given a pickled model and a set of required packages, this function
     initializes a folder to be a valid Hugging Face scikit-learn based repo.
 
     Parameters
@@ -255,10 +260,10 @@ def init(
 
         The first 3 input values are used as example inputs.
 
-        If ``task`` is ``tabular-classification`` or ``tabular-regression``,
-        the data needs to be a ``pandas.DataFrame`` or a ``numpy.ndarray``. If
-        ``task`` is ``text-classification`` or ``text-regression``, the data
-        needs to be a ``list`` of strings.
+        If ``task`` is ``"tabular-classification"`` or ``"tabular-regression"``,
+        the data needs to be a :class:`pandas.DataFrame` or a
+        :class:`numpy.ndarray`. If ``task`` is ``"text-classification"`` or
+        ``"text-regression"``, the data needs to be a ``list`` of strings.
 
     Returns
     -------
@@ -332,7 +337,7 @@ def push(
         A folder where the contents of the model repo are located.
 
     token: str, optional
-        A token to push to the hub. If not provided, the user should be already
+        A token to push to the Hub. If not provided, the user should be already
         logged in using ``huggingface-cli login``.
 
     commit_message: str, optional
@@ -348,10 +353,11 @@ def push(
     -------
     None
 
-    Notes
-    -----
-    This function raises a ``TypeError`` if the contents of the source folder
-    do not make a valid Hugging Face Hub scikit-learn based repo.
+    Raises
+    ------
+    TypeError
+        This function raises a ``TypeError`` if the contents of the source
+        folder do not make a valid Hugging Face Hub scikit-learn based repo.
     """
     _validate_folder(path=source)
     client = HfApi()
@@ -454,7 +460,8 @@ def download(
         newer versions of them.
 
     kwargs: dict
-        Other parameters to be passed to ``huggingface_hub.snapshot_download``.
+        Other parameters to be passed to
+        :func:`huggingface_hub.snapshot_download`.
 
     Returns
     -------


### PR DESCRIPTION
Fixes #93

With this extension, skops docs can link, for instance, to the sklearn
docs.

On top of adding the extension, I made the following changes:

- Adjust links to external docs where appropriate
- Fix minor issues I found in the docs
- Remove autodocs for type annotations, as they were redundant with the
  docstrings (but less detailed)