### PR TITLE
TST Add tests for when pandas is not installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ addopts = "--cov=skops --cov-report=term-missing"
 omit = [
     "skops/**/test_*.py",
     "skops/_min_dependencies.py",
+    "skops/conftest.py",
 ]
 
 [tool.mypy]

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -3,7 +3,6 @@ import os
 import pickle
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -391,14 +390,8 @@ class TestTableSection:
         with pytest.raises(ValueError, match=msg):
             TableSection(table=table)
 
-    def test_pandas_not_installed(self, table_dict):
-        # patch import so that it raises an ImportError when trying to import
-        # pandas. This works because pandas is only imported lazily.
-        def mock_import(name, *args, **kwargs):
-            if name == "pandas":
-                raise ImportError
-            return __import__(name, *args, **kwargs)
-
-        with patch("builtins.__import__", side_effect=mock_import):
-            section = TableSection(table=table_dict)
-            assert section._is_pandas_df is False
+    def test_pandas_not_installed(self, table_dict, pandas_not_installed):
+        # use pandas_not_installed fixture from conftest.py to pretend that
+        # pandas is not installed
+        section = TableSection(table=table_dict)
+        assert section._is_pandas_df is False

--- a/skops/conftest.py
+++ b/skops/conftest.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def pandas_not_installed():
+    # patch import so that it raises an ImportError when trying to import
+    # pandas. This works because pandas is only imported lazily.
+    def mock_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError
+        return __import__(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        yield

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -4,7 +4,6 @@ import pickle
 import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 from uuid import uuid4
 
 import numpy as np
@@ -313,24 +312,15 @@ def test_get_column_names():
     assert _get_column_names(X_df) == expected_columns
 
 
-@pytest.fixture
-def pandas_not_installed():
-    # patch import so that it raises an ImportError when trying to import
-    # pandas. This works because pandas is only imported lazily.
-    def mock_import(name, *args, **kwargs):
-        if name == "pandas":
-            raise ImportError
-        return __import__(name, *args, **kwargs)
-
-    with patch("builtins.__import__", side_effect=mock_import):
-        yield
-
-
 def test_get_example_input_pandas_not_installed(pandas_not_installed):
-    # test that function does not raise when pandas import fails
+    # use pandas_not_installed fixture from conftest.py to pretend that pandas
+    # is not installed and check that the function does not raise when pandas
+    # import fails
     _get_example_input(np.ones((5, 10)))
 
 
 def test_get_column_names_pandas_not_installed(pandas_not_installed):
-    # test that function does not raise when pandas import fails
+    # use pandas_not_installed fixture from conftest.py to pretend that pandas
+    # is not installed and check that the function does not raise when pandas
+    # import fails
     _get_column_names(np.ones((5, 10)))

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -4,6 +4,7 @@ import pickle
 import shutil
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 from uuid import uuid4
 
 import numpy as np
@@ -310,3 +311,26 @@ def test_get_column_names():
     expected_columns = [f"column{x}" for x in range(10)]
     X_df = pd.DataFrame(X_array, columns=expected_columns)
     assert _get_column_names(X_df) == expected_columns
+
+
+@pytest.fixture
+def pandas_not_installed():
+    # patch import so that it raises an ImportError when trying to import
+    # pandas. This works because pandas is only imported lazily.
+    def mock_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError
+        return __import__(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        yield
+
+
+def test_get_example_input_pandas_not_installed(pandas_not_installed):
+    # test that function does not raise when pandas import fails
+    _get_example_input(np.ones((5, 10)))
+
+
+def test_get_column_names_pandas_not_installed(pandas_not_installed):
+    # test that function does not raise when pandas import fails
+    _get_column_names(np.ones((5, 10)))


### PR DESCRIPTION
Improves test coverage for the `try ... import pandas ...` parts.

Note: Instead of `try ... except ImportError`, we could also do `with contextlib.suppress(ImportError)` and skip the `except` part. I assume this was not used intentionally, so I left that code as is.