### PR TITLE
ENH Add details tag in methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,9 +17,8 @@ v0.2
   :pr:`94` by `Benjamin Bossan`_.
 - Make :meth:`skops.hub_utils.init` atomic. Now it doesn't leave a trace on the
   filesystem if it fails for some reason. :pr:`60` by `Adrin Jalali`_
-- When adding figures or tables, it's now possible to set ``details_tag=True``
-  to render the content inside a details tag (i.e. folded). :pr:`108` by
-  `Benjamin Bossan`_.
+- When adding figures or tables, it's now possible to set ``folded=True`` to
+  render the content inside a details tag. :pr:`108` by `Benjamin Bossan`_.
 
 v0.1
 ----

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,7 +16,10 @@ v0.2
 - Add method :meth:`.Card.render` which returns the model card as a string.
   :pr:`94` by `Benjamin Bossan`_.
 - Make :meth:`skops.hub_utils.init` atomic. Now it doesn't leave a trace on the
-  filesystem if it fails for some reason. :pr:`60` by `Adrin Jalali`_`
+  filesystem if it fails for some reason. :pr:`60` by `Adrin Jalali`_
+- When adding figures or tables, it's now possible to set ``details_tag=True``
+  to render the content inside a details tag (i.e. folded). :pr:`108` by
+  `Benjamin Bossan`_.
 
 v0.1
 ----

--- a/examples/plot_model_card.py
+++ b/examples/plot_model_card.py
@@ -162,10 +162,11 @@ clf_report = classification_report(
 del clf_report["accuracy"]
 clf_report = pd.DataFrame(clf_report).T.reset_index()
 model_card.add_table(
+    details_tag=True,
     **{
         "Hyperparameter search results": cv_results,
         "Classification report": clf_report,
-    }
+    },
 )
 
 # %%

--- a/examples/plot_model_card.py
+++ b/examples/plot_model_card.py
@@ -162,7 +162,7 @@ clf_report = classification_report(
 del clf_report["accuracy"]
 clf_report = pd.DataFrame(clf_report).T.reset_index()
 model_card.add_table(
-    details_tag=True,
+    folded=True,
     **{
         "Hyperparameter search results": cv_results,
         "Classification report": clf_report,

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -277,7 +277,11 @@ class Card:
 
         Parameters
         ----------
-        details_tag: bool TODO
+        details_tag: bool (default=False)
+            If set to ``True``, the plot will be enclosed in a ``details`` tag.
+            That means the content is folded by default and users have to click
+            to show the content. This option is useful if the added plot is
+            large.
 
         **kwargs : dict
             The arguments should be of the form `name=plot_path`, where `name`
@@ -324,7 +328,11 @@ class Card:
 
         Parameters
         ----------
-        details_tag: bool TODO
+        details_tag: bool (default=False)
+            If set to ``True``, the table will be enclosed in a ``details`` tag.
+            That means the content is folded by default and users have to click
+            to show the content. This option is useful if the added table is
+            large.
 
         **kwargs : dict
             The keys should be strings, which will be used as the section

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -22,8 +22,8 @@ aRepr.maxother = 79
 aRepr.maxstring = 79
 
 
-def wrap_as_details(text: str, details_tag: bool) -> str:
-    if not details_tag:
+def wrap_as_details(text: str, folded: bool) -> str:
+    if not folded:
         return text
     return f"<details>\n<summary> Click to expand </summary>\n\n{text}\n\n</details>"
 
@@ -34,11 +34,11 @@ class PlotSection:
 
     alt_text: str
     path: str | Path
-    details_tag: bool = False
+    folded: bool = False
 
     def format(self) -> str:
         text = f"![{self.alt_text}]({self.path})"
-        return wrap_as_details(text, details_tag=self.details_tag)
+        return wrap_as_details(text, folded=self.folded)
 
     def __repr__(self) -> str:
         return repr(self.path)
@@ -49,7 +49,7 @@ class TableSection:
     """Adds a table to the model card"""
 
     table: dict["str", list[Any]]
-    details_tag: bool = False
+    folded: bool = False
 
     def __post_init__(self) -> None:
         try:
@@ -81,7 +81,7 @@ class TableSection:
         table = tabulate(
             self.table, tablefmt="github", headers=headers, showindex=False
         )
-        return wrap_as_details(table, details_tag=self.details_tag)
+        return wrap_as_details(table, folded=self.folded)
 
     def __repr__(self) -> str:
         if self._is_pandas_df:
@@ -272,12 +272,12 @@ class Card:
             self._template_sections[section] = value
         return self
 
-    def add_plot(self, details_tag=False, **kwargs: str) -> "Card":
+    def add_plot(self, folded=False, **kwargs: str) -> "Card":
         """Add plots to the model card.
 
         Parameters
         ----------
-        details_tag: bool (default=False)
+        folded: bool (default=False)
             If set to ``True``, the plot will be enclosed in a ``details`` tag.
             That means the content is folded by default and users have to click
             to show the content. This option is useful if the added plot is
@@ -295,15 +295,11 @@ class Card:
             Card object.
         """
         for plot_name, plot_path in kwargs.items():
-            section = PlotSection(
-                alt_text=plot_name, path=plot_path, details_tag=details_tag
-            )
+            section = PlotSection(alt_text=plot_name, path=plot_path, folded=folded)
             self._extra_sections.append((plot_name, section))
         return self
 
-    def add_table(
-        self, details_tag: bool = False, **kwargs: dict["str", list[Any]]
-    ) -> Card:
+    def add_table(self, folded: bool = False, **kwargs: dict["str", list[Any]]) -> Card:
         """Add a table to the model card.
 
         Add a table to the model card. This can be especially useful when you
@@ -328,7 +324,7 @@ class Card:
 
         Parameters
         ----------
-        details_tag: bool (default=False)
+        folded: bool (default=False)
             If set to ``True``, the table will be enclosed in a ``details`` tag.
             That means the content is folded by default and users have to click
             to show the content. This option is useful if the added table is
@@ -349,7 +345,7 @@ class Card:
 
         """
         for key, val in kwargs.items():
-            section = TableSection(table=val, details_tag=details_tag)
+            section = TableSection(table=val, folded=folded)
             self._extra_sections.append((key, section))
         return self
 

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -323,13 +323,13 @@ class TestPlotSection:
         expected = "'path/plot.png'"
         assert str(section) == expected
 
-    @pytest.mark.parametrize("details_tag", [True, False])
-    def test_details_tag(self, details_tag):
+    @pytest.mark.parametrize("folded", [True, False])
+    def test_folded(self, folded):
         section = PlotSection(
-            alt_text="some title", path="path/plot.png", details_tag=details_tag
+            alt_text="some title", path="path/plot.png", folded=folded
         )
         output = section.format()
-        if details_tag:
+        if folded:
             assert "<details>" in output
         else:
             assert "<details>" not in output
@@ -391,11 +391,11 @@ class TestTableSection:
         section = TableSection(table=table_dict)
         assert section._is_pandas_df is False
 
-    @pytest.mark.parametrize("details_tag", [True, False])
-    def test_details_tag(self, table_dict, details_tag):
-        section = TableSection(table=table_dict, details_tag=details_tag)
+    @pytest.mark.parametrize("folded", [True, False])
+    def test_folded(self, table_dict, folded):
+        section = TableSection(table=table_dict, folded=folded)
         output = section.format()
-        if details_tag:
+        if folded:
             assert "<details>" in output
         else:
             assert "<details>" not in output

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -323,6 +323,17 @@ class TestPlotSection:
         expected = "'path/plot.png'"
         assert str(section) == expected
 
+    @pytest.mark.parametrize("details_tag", [True, False])
+    def test_details_tag(self, details_tag):
+        section = PlotSection(
+            alt_text="some title", path="path/plot.png", details_tag=details_tag
+        )
+        output = section.format()
+        if details_tag:
+            assert "<details>" in output
+        else:
+            assert "<details>" not in output
+
 
 class TestTableSection:
     @pytest.fixture
@@ -379,3 +390,12 @@ class TestTableSection:
         # pandas is not installed
         section = TableSection(table=table_dict)
         assert section._is_pandas_df is False
+
+    @pytest.mark.parametrize("details_tag", [True, False])
+    def test_details_tag(self, table_dict, details_tag):
+        section = TableSection(table=table_dict, details_tag=details_tag)
+        output = section.format()
+        if details_tag:
+            assert "<details>" in output
+        else:
+            assert "<details>" not in output


### PR DESCRIPTION
Fixes #107

When passing `details_tag=True` for figures or tables, those are now
folded.

Note that this does not work for content added via the add method, since
that content relies on the existing template. Therefore, to change that,
the template has to be changed.

To see the results, look here:

* [Plot](https://huggingface.co/skops-ci/hf_hub_example-fcc9ddb0-1904-4bb6-ae49-e7fd1d2d589c#confusion-matrix)
* [Tables](https://huggingface.co/skops-ci/hf_hub_example-fcc9ddb0-1904-4bb6-ae49-e7fd1d2d589c#hyperparameter-search-results)