### PR TITLE
MNT Remove redundant test in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         SUPER_SECRET: ${{ secrets.HF_HUB_TOKEN }}
       run: |
-        python -m pytest -s --cov=skops --cov-report=xml --doctest-modules -v skops/
+        python -m pytest -s -v --cov-report=xml skops/
 
     - name: Mypy
       run: mypy --config-file pyproject.toml skops

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,13 +48,7 @@ jobs:
       env:
         SUPER_SECRET: ${{ secrets.HF_HUB_TOKEN }}
       run: |
-        python -m pytest -s --cov=skops --cov-report=xml -v skops/
-
-    - name: Doc Tests
-      env:
-        SUPER_SECRET: ${{ secrets.HF_HUB_TOKEN }}
-      run: |
-        python -m pytest -s --cov=skops --doctest-modules skops/
+        python -m pytest -s --cov=skops --cov-report=xml --doctest-modules -v skops/
 
     - name: Mypy
       run: mypy --config-file pyproject.toml skops


### PR DESCRIPTION
As discussed, the "Tests" and "Doc Tests" tasks are redundant. Since CI
is already quite slow as is, we really don't want to run all the tests
twice. Therefore, the "Doc Tests" task is removed.

Ideally, we would have one task for only doctests and one for unit tests
but AFAICT, there is no option to _only_ run doctests.