### PR TITLE
CI Reduce CI timeout from 60 to 15 min

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10"]
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
After checking a couple of runs, none that took longer than 12 min ever
finished. Therefore, let's cap the timeout at 15 min for now.

Later, if/when we factor out the inference tests, we may decrease the
timeout even further.