### PR TITLE
MNT Persist clean up and consistency checks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10"]
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,12 +1,13 @@
 import io
+from contextlib import suppress
 from pathlib import Path
 from uuid import uuid4
 
 import numpy as np
 
 from ._general import function_get_instance
-from ._persist import get_instance, get_state
-from ._utils import _import_obj, get_module
+from ._utils import _get_instance, _get_state, _import_obj, get_module
+from .exceptions import UnsupportedTypeException
 
 
 def ndarray_get_state(obj, dst):
@@ -15,27 +16,32 @@ def ndarray_get_state(obj, dst):
         "__module__": get_module(type(obj)),
     }
 
-    try:
+    # First, try to save object with np.save and allow_pickle=False, which
+    # should generally work as long as the dtype is not object.
+    with suppress(ValueError):
         f_name = f"{uuid4()}.npy"
         with open(Path(dst) / f_name, "wb") as f:
             np.save(f, obj, allow_pickle=False)
-            res["type"] = "numpy"
-            res["file"] = f_name
-    except ValueError:
-        # Object arrays cannot be saved with allow_pickle=False, therefore we
-        # convert them to a list and recursively call get_state on it.
-        if obj.dtype == object:
-            obj_serialized = get_state(obj.tolist(), dst)
-            res["content"] = obj_serialized["content"]
-            res["type"] = "json"
-            res["shape"] = get_state(obj.shape, dst)
-        else:
-            raise TypeError(f"numpy arrays of dtype {obj.dtype} are not supported yet")
+        res.update(type="numpy", file=f_name)
+        return res
 
+    # Object arrays cannot be saved with allow_pickle=False, therefore we
+    # convert them to a list and recursively call get_state on it. For this, we
+    # expect the dtype to be object.
+    if obj.dtype != object:
+        raise UnsupportedTypeException(
+            f"numpy arrays of dtype {obj.dtype} are not supported yet"
+        )
+
+    obj_serialized = _get_state(obj.tolist(), dst)
+    res["content"] = obj_serialized["content"]
+    res["type"] = "json"
+    res["shape"] = _get_state(obj.shape, dst)
     return res
 
 
 def ndarray_get_instance(state, src):
+    # Dealing with a regular numpy array, where dtype != object
     if state["type"] == "numpy":
         val = np.load(io.BytesIO(src.read(state["file"])), allow_pickle=False)
         # Coerce type, because it may not be conserved by np.save/load. E.g. a
@@ -43,19 +49,20 @@ def ndarray_get_instance(state, src):
         if state["__class__"] != "ndarray":
             cls = _import_obj(state["__module__"], state["__class__"])
             val = cls(val)
+        return val
+
+    # We explicitly set the dtype to "O" since we only save object arrays in
+    # json.
+    shape = _get_instance(state["shape"], src)
+    tmp = [_get_instance(s, src) for s in state["content"]]
+    # TODO: this is a hack to get the correct shape of the array. We should
+    # find _a better way to do this.
+    if len(shape) == 1:
+        val = np.ndarray(shape=len(tmp), dtype="O")
+        for i, v in enumerate(tmp):
+            val[i] = v
     else:
-        # We explicitly set the dtype to "O" since we only save object arrays
-        # in json.
-        shape = get_instance(state["shape"], src)
-        tmp = [get_instance(s, src) for s in state["content"]]
-        # TODO: this is a hack to get the correct shape of the array. We should
-        # find a better way to do this.
-        if len(shape) == 1:
-            val = np.ndarray(shape=len(tmp), dtype="O")
-            for i, v in enumerate(tmp):
-                val[i] = v
-        else:
-            val = np.array(tmp, dtype="O")
+        val = np.array(tmp, dtype="O")
     return val
 
 
@@ -64,25 +71,24 @@ def maskedarray_get_state(obj, dst):
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
         "content": {
-            "data": get_state(obj.data, dst),
-            "mask": get_state(obj.mask, dst),
+            "data": _get_state(obj.data, dst),
+            "mask": _get_state(obj.mask, dst),
         },
     }
     return res
 
 
 def maskedarray_get_instance(state, src):
-    data = get_instance(state["content"]["data"], src)
-    mask = get_instance(state["content"]["mask"], src)
+    data = _get_instance(state["content"]["data"], src)
+    mask = _get_instance(state["content"]["mask"], src)
     return np.ma.MaskedArray(data, mask)
 
 
 def random_state_get_state(obj, dst):
-    content = get_state(obj.get_state(legacy=False), dst)
+    content = _get_state(obj.get_state(legacy=False), dst)
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
-        "type": "numpy",
         "content": content,
     }
     return res
@@ -91,7 +97,7 @@ def random_state_get_state(obj, dst):
 def random_state_get_instance(state, src):
     cls = _import_obj(state["__module__"], state["__class__"])
     random_state = cls()
-    content = get_instance(state["content"], src)
+    content = _get_instance(state["content"], src)
     random_state.set_state(content)
     return random_state
 
@@ -101,7 +107,6 @@ def random_generator_get_state(obj, dst):
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
-        "type": "numpy",
         "content": {"bit_generator": bit_generator_state},
     }
     return res

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -28,7 +28,9 @@ def ndarray_get_state(obj, dst):
         # we expect the dtype to be object.
         if obj.dtype != object:
             raise UnsupportedTypeException(
-                f"numpy arrays of dtype {obj.dtype} are not supported yet"
+                f"numpy arrays of dtype {obj.dtype} are not supported yet, please "
+                "open an issue at https://github.com/skops-dev/skops/issues and "
+                "report your error"
             )
 
         obj_serialized = _get_state(obj.tolist(), dst)

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -1,8 +1,10 @@
+import importlib
+import inspect
 import json
 import sys
 import warnings
 from collections import Counter
-from functools import partial
+from functools import partial, wraps
 from zipfile import ZipFile
 
 import numpy as np
@@ -50,6 +52,7 @@ from sklearn.utils.estimator_checks import (
 import skops
 from skops.io import load, save
 from skops.io._sklearn import UNSUPPORTED_TYPES
+from skops.io._utils import get_instance, get_state
 from skops.io.exceptions import UnsupportedTypeException
 
 # Default settings for X
@@ -59,6 +62,57 @@ N_FEATURES = 20
 # TODO: Investigate why that seems to be an issue on MacOS (only observed with
 # Python 3.8)
 ATOL = 1e-6 if sys.platform == "darwin" else 1e-7
+
+
+@pytest.fixture(autouse=True)
+def debug_dispatch_functions():
+    # Patch the get_state and get_instance methods to add some sanity checks on
+    # them.
+
+    def debug_get_state(func):
+        # check consistency of argument names and output type
+        signature = inspect.signature(func)
+        assert list(signature.parameters.keys()) == ["obj", "dst"]
+
+        @wraps(func)
+        def wrapper(obj, dst):
+            result = func(obj, dst)
+            if isinstance(result, dict):
+                assert "__class__" in result
+                assert "__module__" in result
+            else:
+                # should be a primitive type
+                assert isinstance(result, (int, float, str))
+            return result
+
+        return wrapper
+
+    def debug_get_instance(func):
+        # check consistency of argument names and output type
+        signature = inspect.signature(func)
+        assert list(signature.parameters.keys()) == ["state", "src"]
+
+        @wraps(func)
+        def wrapper(state, src):
+            if isinstance(state, dict):
+                assert "__class__" in state
+                assert "__module__" in state
+            else:
+                # should be a primitive type
+                assert isinstance(state, (int, float, str))
+            result = func(state, src)
+            return result
+
+        return wrapper
+
+    modules = ["._general", "._numpy", "._scipy", "._sklearn"]
+    for module_name in modules:
+        # overwrite exposed functions for get_state and get_instance
+        module = importlib.import_module(module_name, package="skops.io")
+        for cls, method in getattr(module, "GET_STATE_DISPATCH_FUNCTIONS", []):
+            get_state.register(cls)(debug_get_state(method))
+        for cls, method in getattr(module, "GET_INSTANCE_DISPATCH_FUNCTIONS", []):
+            get_instance.register(cls)(debug_get_instance(method))
 
 
 def save_load_round(estimator, f_name):

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -76,7 +76,10 @@ def debug_dispatch_functions():
 
         @wraps(func)
         def wrapper(obj, dst):
+            assert isinstance(dst, str)
+
             result = func(obj, dst)
+
             if isinstance(result, dict):
                 assert "__class__" in result
                 assert "__module__" in result
@@ -88,7 +91,7 @@ def debug_dispatch_functions():
         return wrapper
 
     def debug_get_instance(func):
-        # check consistency of argument names and output type
+        # check consistency of argument names and input type
         signature = inspect.signature(func)
         assert list(signature.parameters.keys()) == ["state", "src"]
 
@@ -100,7 +103,10 @@ def debug_dispatch_functions():
             else:
                 # should be a primitive type
                 assert isinstance(state, (int, float, str))
+            assert isinstance(src, ZipFile)
+
             result = func(state, src)
+
             return result
 
         return wrapper

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -67,10 +67,13 @@ ATOL = 1e-6 if sys.platform == "darwin" else 1e-7
 @pytest.fixture(autouse=True)
 def debug_dispatch_functions():
     # Patch the get_state and get_instance methods to add some sanity checks on
-    # them.
+    # them. Specifically, we test that the arguments of the functions all follow
+    # the same pattern to enforce consistency and that the "state" is either a
+    # dict with specified keys or a primitive type.
 
     def debug_get_state(func):
-        # check consistency of argument names and output type
+        # Check consistency of argument names, output type, and that the output,
+        # if a dict, has certain keys, or if not a dict, is a primitive type.
         signature = inspect.signature(func)
         assert list(signature.parameters.keys()) == ["obj", "dst"]
 


### PR DESCRIPTION
During the work on adding strict typing (which will most likely not
work), a couple of opportunities for simplifications and clean ups came
up. In order for them not to get lost in the typing PR, they are now
added in this separate PR. Changes are:

- A few simplifications to the `state` to avoid unnecessary nesting
- Consistently raise `UnsupportedTypeException`
- Simplify some code without without functional change
- Consistently use `_get_state` and `_get_instance`
- Enforce consistency on the argument names in `get_state/instance`
  functions

Regarding the use of `_get_state` vs `get_state` and `_get_instance` vs `get_instance`:
Since we basically only ever want to use the `_get` variant and not `get` (since the
latter are only placeholders for registration), I would suggest that we swap the
names. This will also be better for future contributions to 3rd party libraries,
since right now they would be required to use "private" functions.

Ready for review @skops-dev/maintainers 

(PS: Sorry for spurious commits, I'll clean them up)