### PR TITLE
Avoid duplicating numpy arrays

### DIFF
--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -8,6 +8,7 @@ import numpy as np
 from ._general import function_get_instance
 from ._persist import get_instance, get_state
 from ._utils import _import_obj, get_module
+from .exceptions import UnsupportedTypeException
 
 
 def ndarray_get_state(obj, dst):
@@ -30,7 +31,7 @@ def ndarray_get_state(obj, dst):
                 f"numpy arrays of type {type(obj)} and dtype {obj.dtype} are not "
                 "supported yet"
             )
-            raise TypeError(msg) from exc
+            raise UnsupportedTypeException(msg) from exc
     else:
         # Object arrays cannot be saved with allow_pickle=False, therefore we
         # convert them to a list and recursively call get_state on it.

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,7 +1,8 @@
 import io
+import os
 from pathlib import Path
-from uuid import uuid4
 
+import joblib
 import numpy as np
 
 from ._general import function_get_instance
@@ -16,11 +17,13 @@ def ndarray_get_state(obj, dst):
     }
 
     try:
-        f_name = f"{uuid4()}.npy"
-        with open(Path(dst) / f_name, "wb") as f:
-            np.save(f, obj, allow_pickle=False)
-            res["type"] = "numpy"
-            res["file"] = f_name
+        digest = joblib.hash(obj)
+        f_name = f"{digest}.npy"
+        if not os.path.exists(f_name):
+            with open(Path(dst) / f_name, "wb") as f:
+                np.save(f, obj, allow_pickle=False)
+        res["type"] = "numpy"
+        res["file"] = f_name
     except ValueError:
         # Object arrays cannot be saved with allow_pickle=False, therefore we
         # convert them to a list and recursively call get_state on it.


### PR DESCRIPTION
Fixes #135

## Description

Instead of using a UUID for the name of the numpy files, use their hash. That way, when the same array already exists, we can use it instead of storing another copy.

## Implementation

I started out with using `hashlib.sha256` instead of delegating hashing to joblib. However, this caused several problems:

- sha256 only worked for C-contiguous arrays
- the sha256 of `np.array(0)`, `np.array([0])`, `np.array([[0]])` etc. were all the same, which prevents us from restoring the arrays to their original shape

I did not try the other hashlib algorithms. Both drawbacks could be worked around (store the contiguity and shape and restore them after loading, but see #149), but since joblib is already a dependency, I just went with it.

The disadvantage of `joblib.hash` is that it uses either md5 or sha1, both of which are not cryptographically secure anymore. However, for this use case, that should not be a necessity, since the hash only serves as a cache key.

**Addendum**

While working on this, I discovered a minor bug where trying to store an object numpy array resulted in the creation of a broken `.npy` file being left over. This is because numpy tries to write to the file until it encounters an error and raises, but then doesn't clean up said file. Before this bugfix, we would include that broken file in the zip archive, although we wouldn't do anything with it. Now, no such file is being created. A test is added to test this.