### PR TITLE
MNT Add matplotlib and pandas as test dependencies

### DIFF
--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -25,8 +25,8 @@ dependent_packages = {
     "numpydoc": ("1.0.0", "docs", None),
     "sphinx-prompt": ("1.3.0", "docs", None),
     "sphinx-issues": ("1.2.0", "docs", None),
-    "matplotlib": ("3.3", "docs", None),
-    "pandas": ("1", "docs", None),
+    "matplotlib": ("3.3", "docs, tests", None),
+    "pandas": ("1", "docs, tests", None),
     "typing_extensions": ("3.7", "install", "python_full_version < '3.8'"),
 }
 


### PR DESCRIPTION
Fixes #148

## Description

matplotlib and pandas are currently not test dependencies (only docs) but actually, tests cannot run without them.

Now it should be possible to successfully run:

```
pip install skops[tests]
pytest skops
```

(I successfully tested locally with `pip install -e .[tests]`)

## Implementation

There was already the possibility to declare the same dependency for multiple `extras` by using `", "` as separator. Personally, I would have preferred a tuple like so:

```python
dependent_packages = {
    ...,
    ("pandas": ("1", ("docs", "tests"), None)),
}
```

but I guess the code is like this because sklearn does it [the same](https://github.com/scikit-learn/scikit-learn/blob/ae6bf39b310ed5bb46349c831a05f55bba921dcc/sklearn/_min_dependencies.py#L60).

## Other

If merged, allows to simplify install in #147