### PR TITLE
Fix FutureWarnings for huggingface_hub>=0.10

### DIFF
--- a/skops/utils/fixes.py
+++ b/skops/utils/fixes.py
@@ -6,6 +6,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import List
 
+from scipy._lib._pep440 import Version  # noqa
+
 if sys.version_info >= (3, 8):
     # py>=3.8
     from importlib import metadata  # noqa


### PR DESCRIPTION
For that Hub version, the use of the `token` argument produces a `FutureWarning`, leading our CI to fail. This PR fixes the warnings while leaving everything the same on the user side (i.e. they don't need to change the `token` argument).

## Implementation

As discussed, we will not change the argument name on the skops, preferring token to `use_auth_token`.

For the version checking, I went with the private `Version` class from [scipy](https://github.com/scipy/scipy/blob/main/scipy/_lib/_pep440.py), which follows PEP440. This follows the approach taken in skorch (see this issue: https://github.com/skorch-dev/skorch/issues/887), though we import it here instead of vendoring. Let me know if another approach is preferred.