### PR TITLE
BUG Fix line breaks in markdown tables

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ v0.3
 - Add ``private`` as an optional argument to :meth:`.hub_utils.push` to
   optionally set the visibility status of a repo when pushing to the hub.
   :pr:`130` by `Adrin Jalali`_.
+- Fix a bug that resulted in markdown tables being rendered incorrectly if
+  entries contained line breaks by `Benjamin Bossan`_.
 
 v0.2
 ----

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -68,6 +68,19 @@ def test_hyperparameter_table(destination_path, model_card):
     assert "fit_intercept" in model_card
 
 
+def test_hyperparameter_table_with_line_break(destination_path):
+    # Hyperparameters can contain values with line breaks, "\n", in them. In
+    # that case, the markdown table is broken. Check that the hyperparameter
+    # table we create properly replaces the "\n" with "<br />".
+    class EstimatorWithLbInParams:
+        def get_params(self, deep=False):
+            return {"fit_intercept": True, "n_jobs": "line\nwith\nbreak"}
+
+    model_card = Card(EstimatorWithLbInParams())
+    model_card = model_card.render()
+    assert "| n_jobs           | line<br />with<br />break         |" in model_card
+
+
 def test_plot_model(destination_path, model_card):
     model_card = model_card.render()
     assert "<style>" in model_card
@@ -415,3 +428,35 @@ class TestTableSection:
             assert "<details>" in output
         else:
             assert "<details>" not in output
+
+    def test_line_break_in_entry(self, table_dict):
+        # Line breaks are not allowed inside markdown tables, so check that
+        # they're removed. We test 3 conditions here:
+
+        # 1. custom object with line breaks in repr
+        # 2. string with line break in the middle
+        # 3. string with line break at start, middle, and end
+
+        # Note that for the latter, tabulate will automatically strip the line
+        # breaks from the start and end.
+        class LineBreakInRepr:
+            """Custom object whose repr has a line break"""
+
+            def __repr__(self) -> str:
+                return "obj\nwith lb"
+
+        table_dict["with break"] = [
+            LineBreakInRepr(),
+            "hi\nthere",
+            """
+entry with
+line breaks
+""",
+        ]
+        section = TableSection(table=table_dict)
+        expected = """|   split |   score | with break   |
+|---------|---------|--------------|
+|       1 |       4 | obj<br />with lb              |
+|       2 |       5 | hi<br />there              |
+|       3 |       6 | entry with<br />line breaks              |"""
+        assert section.format() == expected


### PR DESCRIPTION
Solves #154 

## Description

Markdown table entires shouldn't contain `"\n"` line breaks. Instead, those should be replaced by `"<br />"`. This is now done for both the hyperparameter table and for tables added through `card.add_table`.

An example of a fixed hyperparameter table: https://huggingface.co/skops-ci/hf_hub_example-a4b4abaf-d1c3-4300-a5ac-cc9e3c65bd39#hyperparameters

## Implementation

The bugfix has to be applied after calling `tabulate`, as the table entries can contain arbitrary objects, whose `repr` is only called by tabulate. That also means we have to be careful as the tabulated table string will contain valid `"\n"` line breaks that should be left untouched.

Unfortunately, the hyperparameter table doesn't use `card.add_table`, which is why the fix has to be applied in two places. IMO it would be better if it used that method under the hood but that would result in the hyperparameter table being placed in a different section (because of the inflexibility of the templating).

A minor naming issue I found: The method that actually creates the hyperparameter table is called `_extract_estimator_config`. I would have never guessed to be honest.