### PR TITLE
CI Pin HF Hub version, unpin Python 3.10.6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false  # need to see which ones fail
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.7", "3.8", "3.9", "3.10.6"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 15
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[docs,tests]
-        pip install black=="22.6.0" isort=="5.10.1" mypy=="0.971"
+        pip install black=="22.6.0" isort=="5.10.1" mypy=="0.981"
         python --version
         pip --version
         pip list

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -11,7 +11,7 @@ PYTEST_MIN_VERSION = "5.0.1"
 #     "tomli": ("1.1.0", "install", "python_full_version < '3.11.0a7'"),
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
-    "huggingface_hub": ("0.9.0rc3", "install", None),
+    "huggingface_hub": ("0.9.0rc3,<0.10.0rc0", "install", None),
     "modelcards": ("0.1.6", "install", None),
     "tabulate": ("0.8.8", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),


### PR DESCRIPTION
- Pinning Hub until we fix the existing issues (#152)
- Pinning Python 3.10.6 should no longer be necessary with the 0.981 release of mypy (solving mypy issue 13627)