### PR TITLE
MNT Swap the names of _get_state <=> get_state & _get_instance <=> get_instance

### DIFF
--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import numpy as np
 
 from ._general import function_get_instance
-from ._utils import _get_instance, _get_state, _import_obj, get_module
+from ._utils import _import_obj, get_instance, get_module, get_state
 from .exceptions import UnsupportedTypeException
 
 
@@ -33,10 +33,10 @@ def ndarray_get_state(obj, dst):
                 "report your error"
             )
 
-        obj_serialized = _get_state(obj.tolist(), dst)
+        obj_serialized = get_state(obj.tolist(), dst)
         res["content"] = obj_serialized["content"]
         res["type"] = "json"
-        res["shape"] = _get_state(obj.shape, dst)
+        res["shape"] = get_state(obj.shape, dst)
 
     return res
 
@@ -54,8 +54,8 @@ def ndarray_get_instance(state, src):
 
     # We explicitly set the dtype to "O" since we only save object arrays in
     # json.
-    shape = _get_instance(state["shape"], src)
-    tmp = [_get_instance(s, src) for s in state["content"]]
+    shape = get_instance(state["shape"], src)
+    tmp = [get_instance(s, src) for s in state["content"]]
     # TODO: this is a hack to get the correct shape of the array. We should
     # find _a better way to do this.
     if len(shape) == 1:
@@ -72,21 +72,21 @@ def maskedarray_get_state(obj, dst):
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
         "content": {
-            "data": _get_state(obj.data, dst),
-            "mask": _get_state(obj.mask, dst),
+            "data": get_state(obj.data, dst),
+            "mask": get_state(obj.mask, dst),
         },
     }
     return res
 
 
 def maskedarray_get_instance(state, src):
-    data = _get_instance(state["content"]["data"], src)
-    mask = _get_instance(state["content"]["mask"], src)
+    data = get_instance(state["content"]["data"], src)
+    mask = get_instance(state["content"]["mask"], src)
     return np.ma.MaskedArray(data, mask)
 
 
 def random_state_get_state(obj, dst):
-    content = _get_state(obj.get_state(legacy=False), dst)
+    content = get_state(obj.get_state(legacy=False), dst)
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
@@ -98,7 +98,7 @@ def random_state_get_state(obj, dst):
 def random_state_get_instance(state, src):
     cls = _import_obj(state["__module__"], state["__class__"])
     random_state = cls()
-    content = _get_instance(state["content"], src)
+    content = get_instance(state["content"], src)
     random_state.set_state(content)
     return random_state
 

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 
 import skops
 
-from ._utils import get_instance, get_state
+from ._utils import _get_instance, _get_state
 
 # For now, there is just one protocol version
 PROTOCOL = 0
@@ -22,9 +22,9 @@ for module_name in modules:
     # register exposed functions for get_state and get_instance
     module = importlib.import_module(module_name, package="skops.io")
     for cls, method in getattr(module, "GET_STATE_DISPATCH_FUNCTIONS", []):
-        get_state.register(cls)(method)
+        _get_state.register(cls)(method)
     for cls, method in getattr(module, "GET_INSTANCE_DISPATCH_FUNCTIONS", []):
-        get_instance.register(cls)(method)
+        _get_instance.register(cls)(method)
 
 
 def save(obj, file):
@@ -54,7 +54,7 @@ def save(obj, file):
     """
     with tempfile.TemporaryDirectory() as dst:
         with open(Path(dst) / "schema.json", "w") as f:
-            state = get_state(obj, dst)
+            state = _get_state(obj, dst)
             state["protocol"] = PROTOCOL
             state["_skops_version"] = skops.__version__
             json.dump(state, f, indent=2)
@@ -93,5 +93,5 @@ def load(file):
     """
     with ZipFile(file, "r") as input_zip:
         schema = input_zip.read("schema.json")
-        instance = get_instance(json.loads(schema), input_zip)
+        instance = _get_instance(json.loads(schema), input_zip)
     return instance

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 
 import skops
 
-from ._utils import _get_instance, _get_state
+from ._utils import _get_instance, _get_state, get_instance, get_state
 
 # For now, there is just one protocol version
 PROTOCOL = 0
@@ -54,7 +54,7 @@ def save(obj, file):
     """
     with tempfile.TemporaryDirectory() as dst:
         with open(Path(dst) / "schema.json", "w") as f:
-            state = _get_state(obj, dst)
+            state = get_state(obj, dst)
             state["protocol"] = PROTOCOL
             state["_skops_version"] = skops.__version__
             json.dump(state, f, indent=2)
@@ -93,5 +93,5 @@ def load(file):
     """
     with ZipFile(file, "r") as input_zip:
         schema = input_zip.read("schema.json")
-        instance = _get_instance(json.loads(schema), input_zip)
+        instance = get_instance(json.loads(schema), input_zip)
     return instance

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -15,7 +15,7 @@ from sklearn.tree._tree import Tree
 from sklearn.utils import Bunch
 
 from ._general import dict_get_instance, dict_get_state, unsupported_get_state
-from ._utils import _get_instance, _get_state, get_module, gettype
+from ._utils import get_instance, get_module, get_state, gettype
 from .exceptions import UnsupportedTypeException
 
 ALLOWED_SGD_LOSSES = {
@@ -56,7 +56,7 @@ def reduce_get_state(obj, dst):
     # As a good example, this makes Tree object to be serializable.
     reduce = obj.__reduce__()
     res["__reduce__"] = {}
-    res["__reduce__"]["args"] = _get_state(reduce[1], dst)
+    res["__reduce__"]["args"] = get_state(reduce[1], dst)
 
     if len(reduce) == 3:
         # reduce includes what's needed for __getstate__ and we don't need to
@@ -74,16 +74,16 @@ def reduce_get_state(obj, dst):
             f"Objects of type {res['__class__']} not supported yet"
         )
 
-    res["content"] = _get_state(attrs, dst)
+    res["content"] = get_state(attrs, dst)
     return res
 
 
 def reduce_get_instance(state, src, constructor):
     reduce = state["__reduce__"]
-    args = _get_instance(reduce["args"], src)
+    args = get_instance(reduce["args"], src)
     instance = constructor(*args)
 
-    attrs = _get_instance(state["content"], src)
+    attrs = get_instance(state["content"], src)
     if not attrs:
         # nothing more to do
         return instance

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -211,21 +211,27 @@ def get_module(obj):
 
 
 @singledispatch
-def get_state(obj, dst):
+def _get_state(obj, dst):
+    # This function should never be called directly. Instead, it is used to
+    # dispatch to the correct implementation of get_state for the given type of
+    # its first argument.
     raise TypeError(f"Getting the state of type {type(obj)} is not supported yet")
 
 
 @singledispatch
-def get_instance(obj):
+def _get_instance(obj, src):
+    # This function should never be called directly. Instead, it is used to
+    # dispatch to the correct implementation of get_instance for the given type
+    # of its first argument.
     raise TypeError(f"Creating an instance of type {type(obj)} is not supported yet")
 
 
-def _get_state(value, dst):
+def get_state(value, dst):
     # This is a helper function to try to get the state of an object. If it
     # fails with `get_state`, we try with json.dumps, if that fails, we raise
     # the original error alongside the json error.
     try:
-        return get_state(value, dst)
+        return _get_state(value, dst)
     except TypeError as e1:
         try:
             return json.dumps(value)
@@ -233,13 +239,13 @@ def _get_state(value, dst):
             raise e1 from e2
 
 
-def _get_instance(value, src):
+def get_instance(value, src):
     # This is a helper function to try to get the state of an object. If
     # `gettype` fails, we load with `json`.
     if value is None:
         return None
 
     if gettype(value):
-        return get_instance(value, src)
+        return _get_instance(value, src)
 
     return json.loads(value)

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -52,7 +52,7 @@ from sklearn.utils.estimator_checks import (
 import skops
 from skops.io import load, save
 from skops.io._sklearn import UNSUPPORTED_TYPES
-from skops.io._utils import get_instance, get_state
+from skops.io._utils import _get_instance, _get_state
 from skops.io.exceptions import UnsupportedTypeException
 
 # Default settings for X
@@ -119,9 +119,9 @@ def debug_dispatch_functions():
         # overwrite exposed functions for get_state and get_instance
         module = importlib.import_module(module_name, package="skops.io")
         for cls, method in getattr(module, "GET_STATE_DISPATCH_FUNCTIONS", []):
-            get_state.register(cls)(debug_get_state(method))
+            _get_state.register(cls)(debug_get_state(method))
         for cls, method in getattr(module, "GET_INSTANCE_DISPATCH_FUNCTIONS", []):
-            get_instance.register(cls)(debug_get_instance(method))
+            _get_instance.register(cls)(debug_get_instance(method))
 
 
 def save_load_round(estimator, f_name):


### PR DESCRIPTION
The functions that should be actually used everywhere are `_get_state` and `_get_instance`, not `get_state` and `get_instance`. This is inconvenient and confusing. Therefore, swap out the names so that the functions being used everywhere now have the "public" name and the other ones the "private" name.

This was discussed [here](https://github.com/skops-dev/skops/pull/143#issue-1376742945).