### PR TITLE
MNT Move to huggingface_hub v0.10

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,8 +20,8 @@ v0.3
   Jalali`_ and `Benjamin Bossan`_. Visit :ref:`persistence` for more
   information. This feature is not production ready yet but we're happy to
   receive feedback from users.
-- Use ``huggingface_hub`` v0.10 for model cards, drop ``modelcards`` dependency
-  by `Benjamin Bossan`_.
+- Use ``huggingface_hub`` v0.10 for model cards, drop ``modelcards`` dependency.
+  :pr:`162` by `Benjamin Bossan`_.
 
 v0.2
 ----

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,13 +13,15 @@ v0.3
 ----
 - Utility function to add arbitrary files to be uploaded to the hub by using
   :func:`.hub_utils.add_files`. :pr:`123` by `Benjamin Bossan`_.
-- Add ``private`` as an optional argument to :meth:`.hub_utils.push` to
+- Add ``private`` as an optional argument to :meth:`skops.hub_utils.push` to
   optionally set the visibility status of a repo when pushing to the hub.
   :pr:`130` by `Adrin Jalali`_.
 - First release of the skops secure persistence feature (:pr:`128`) by `Adrin
   Jalali`_ and `Benjamin Bossan`_. Visit :ref:`persistence` for more
   information. This feature is not production ready yet but we're happy to
   receive feedback from users.
+- Use ``huggingface_hub`` v0.10 for model cards, drop ``modelcards`` dependency
+  by `Benjamin Bossan`_.
 
 v0.2
 ----

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -11,8 +11,7 @@ PYTEST_MIN_VERSION = "5.0.1"
 #     "tomli": ("1.1.0", "install", "python_full_version < '3.11.0a7'"),
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
-    "huggingface_hub": ("0.9.0rc3,<0.10.0rc0", "install", None),
-    "modelcards": ("0.1.6", "install", None),
+    "huggingface_hub": ("0.10.0", "install", None),
     "tabulate": ("0.8.8", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),
     "pytest-cov": ("2.9.0", "tests", None),

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from reprlib import Repr
 from typing import Any, Optional, Union
 
-from modelcards import CardData, ModelCard
+from huggingface_hub import CardData, ModelCard
 from sklearn.utils import estimator_html_repr
 from tabulate import tabulate  # type: ignore
 
@@ -97,10 +97,10 @@ class TableSection:
 def metadata_from_config(config_path: Union[str, Path]) -> CardData:
     """Construct a ``CardData`` object from a ``config.json`` file.
 
-    Most information needed for the metadata section of a ``README.md``
-    file on Hugging Face Hub is included in the ``config.json`` file. This
-    utility function constructs a ``CardData`` object which can then be
-    passed to the :class:`~skops.card.Card` object.
+    Most information needed for the metadata section of a ``README.md`` file on
+    Hugging Face Hub is included in the ``config.json`` file. This utility
+    function constructs a :class:`huggingface_hub.CardData` object which can
+    then be passed to the :class:`~skops.card.Card` object.
 
     This method populates the following attributes of the instance:
 
@@ -120,8 +120,9 @@ def metadata_from_config(config_path: Union[str, Path]) -> CardData:
 
     Returns
     -------
-    card_data: ``modelcards.CardData``
-        ``CardData`` object.
+    card_data: huggingface_hub.CardData
+        :class:`huggingface_hub.CardData` object.
+
     """
     config_path = Path(config_path)
     if not config_path.is_file():
@@ -371,9 +372,9 @@ class Card:
 
         Returns
         -------
-        card : modelcards.ModelCard
-            The final ``ModelCard`` object with all placeholders filled and all
-            extra sections inserted.
+        card : huggingface_hub.ModelCard
+            The final :class:`huggingface_hub.ModelCard` object with all
+            placeholders filled and all extra sections inserted.
         """
         root = skops.__path__
 

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import sklearn
-from huggingface_hub import metadata_load
+from huggingface_hub import CardData, metadata_load
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LinearRegression, LogisticRegression
 
@@ -286,8 +286,6 @@ class TestCardRepr:
 
     @pytest.mark.parametrize("meth", [repr, str])
     def test_with_metadata(self, card: Card, meth):
-        from modelcards import CardData
-
         metadata = CardData(
             language="fr",
             license="bsd",

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -626,7 +626,7 @@ def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> An
     Also note that if the model repo is private, the inference API would not be
     available.
     """
-    model_info = HfApi().model_info(repo_id=repo_id, token=token)
+    model_info = HfApi().model_info(repo_id=repo_id, use_auth_token=token)
     if not model_info.pipeline_tag:
         raise ValueError(
             f"Repo {repo_id} has no pipeline tag. You should set a valid 'task' in"

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -370,7 +370,7 @@ def test_push_download(
     with pytest.raises(OSError, match="None-empty dst path already exists!"):
         download(repo_id=repo_id, dst=destination_path, token=HF_HUB_TOKEN)
 
-    files = client.list_repo_files(repo_id=repo_id, token=HF_HUB_TOKEN)
+    files = client.list_repo_files(repo_id=repo_id, use_auth_token=HF_HUB_TOKEN)
     for f_name in [classifier_pickle.name, config_json.name]:
         assert f_name in files
 


### PR DESCRIPTION
Resolves #155

There are two major changes accompanying this move:

- Model cards have now moved to the hub libary, `modelcards` is deprecated
- Some API changes around `token` => `use_auth_token`

Some docstrings were fixed too.

Comment: Took me several tries to get the `token` => `use_auth_token` transition right, as it's hard to guess what method uses what, and the use of `**kwargs` by some methods is not helping.