### PR TITLE
MNT Model card refactor to move plotting & table

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -409,7 +409,7 @@ class Card:
                         " json.load(f)\n"
                         'clf.predict(pd.DataFrame.from_dict(config["sklearn"]["example_input"]))'
                     )
-        if self._model_diagram is True:
+        if self.model_diagram is True:
             model_plot: str | None = re.sub(
                 r"\n\s+", "", str(estimator_html_repr(self.model))
             )

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -241,15 +241,8 @@ class Card:
         metadata: Optional[CardData] = None,
     ) -> None:
         self.model = model
-        self._hyperparameter_table = self._extract_estimator_config()
-        # the spaces in the pipeline breaks markdown, so we replace them
+        self._model_diagram = model_diagram
         self._eval_results = {}  # type: ignore
-        if model_diagram is True:
-            self._model_plot: str | None = re.sub(
-                r"\n\s+", "", str(estimator_html_repr(model))
-            )
-        else:
-            self._model_plot = None
         self._template_sections: dict[str, str] = {}
         self._extra_sections: list[tuple[str, Any]] = []
         self.metadata = metadata or CardData()
@@ -380,6 +373,8 @@ class Card:
         # add evaluation results
 
         template_sections = copy.deepcopy(self._template_sections)
+        self._hyperparameter_table = self._extract_estimator_config()
+
         if self.metadata:
             model_file = self.metadata.to_dict().get("model_file")
             if model_file:
@@ -390,11 +385,18 @@ class Card:
                     " json.load(f)\n"
                     'clf.predict(pd.DataFrame.from_dict(config["sklearn"]["example_input"]))'
                 )
+        if self._model_diagram is True:
+            self._model_plot: str | None = re.sub(
+                r"\n\s+", "", str(estimator_html_repr(self.model))
+            )
+        else:
+            self._model_plot = None
         template_sections["eval_results"] = tabulate(
             list(self._eval_results.items()),
             headers=["Metric", "Value"],
             tablefmt="github",
         )
+
         # if template path is not given, use default
         if template_sections.get("template_path") is None:
             template_sections["template_path"] = str(

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -373,7 +373,6 @@ class Card:
         # add evaluation results
 
         template_sections = copy.deepcopy(self._template_sections)
-        self._hyperparameter_table = self._extract_estimator_config()
 
         if self.metadata:
             model_file = self.metadata.to_dict().get("model_file")
@@ -386,11 +385,11 @@ class Card:
                     'clf.predict(pd.DataFrame.from_dict(config["sklearn"]["example_input"]))'
                 )
         if self._model_diagram is True:
-            self._model_plot: str | None = re.sub(
+            model_plot: str | None = re.sub(
                 r"\n\s+", "", str(estimator_html_repr(self.model))
             )
         else:
-            self._model_plot = None
+            model_plot = None
         template_sections["eval_results"] = tabulate(
             list(self._eval_results.items()),
             headers=["Metric", "Value"],
@@ -423,8 +422,8 @@ class Card:
 
             card = ModelCard.from_template(
                 card_data=self.metadata,
-                hyperparameter_table=self._hyperparameter_table,
-                model_plot=self._model_plot,
+                hyperparameter_table=self._extract_estimator_config(),
+                model_plot=model_plot,
                 **template_sections,
             )
         return card

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -241,7 +241,7 @@ class Card:
         metadata: Optional[CardData] = None,
     ) -> None:
         self.model = model
-        self._model_diagram = model_diagram
+        self.model_diagram = model_diagram
         self._eval_results = {}  # type: ignore
         self._template_sections: dict[str, str] = {}
         self._extra_sections: list[tuple[str, Any]] = []

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -122,6 +122,12 @@ def test_metadata_keys(destination_path, model_card):
     assert "tags: dummy" in model_card
 
 
+def test_default_sections_save(model_card):
+    # test if the plot and hyperparameters are only added during save
+    assert "<style>" not in str(model_card)
+    assert "fit_intercept" not in str(model_card)
+
+
 def test_add_metrics(destination_path, model_card):
     model_card.add_metrics(**{"acc": 0.1})
     model_card.add_metrics(f1=0.1)


### PR DESCRIPTION
Resolves #157.
I moved plot & hyperparameter table to `_generate_card()` to keep `save()` atomic, given it's already called during `save()`. Does it sound good? 