### PR TITLE
CI Relax dependency of HF hub being < v0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ profile = "black"
 filterwarnings = [
     "error::DeprecationWarning",
     "error::FutureWarning",
+    # TODO: remove line below once we changed hub calls to use use_auth_token
+    "ignore:Deprecated argument\\(s\\) used in 'model_info':FutureWarning",
 ]
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -12,7 +12,7 @@ PYTEST_MIN_VERSION = "5.0.1"
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
     # TODO: remove '<0.12.0rc0' once we changed hub calls to use use_auth_token
-    "huggingface_hub": ("0.9.0rc3,<0.12.0rc0", "install", None),
+    "huggingface_hub": ("0.9.0rc3,<0.11.0rc0", "install", None),
     "modelcards": ("0.1.6", "install", None),
     "tabulate": ("0.8.8", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -11,7 +11,8 @@ PYTEST_MIN_VERSION = "5.0.1"
 #     "tomli": ("1.1.0", "install", "python_full_version < '3.11.0a7'"),
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
-    "huggingface_hub": ("0.9.0rc3,<0.10.0rc0", "install", None),
+    # TODO: remove '<0.12.0rc0' once we changed hub calls to use use_auth_token
+    "huggingface_hub": ("0.9.0rc3,<0.12.0rc0", "install", None),
     "modelcards": ("0.1.6", "install", None),
     "tabulate": ("0.8.8", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),


### PR DESCRIPTION
That restriction was a short term solution because we thought we could make v0.10 work with a few changes. However, that's not the case because of a [bug](https://github.com/skops-dev/skops/pull/162#issuecomment-1263516507) in HF hub model cards on Windows. This requires a bugfix release before it would be fixed.

In the meantime, we should allow users to install v0.10, since there is no technical reason not to use it. The only annoyance is that users will get `FutureWarning`s.

For CI, we filter out corresponding `FutureWarning`s for the time being. Once the HF hub bug is fixed, we can proceed with #162 and remove the filter.