### PR TITLE
MNT Refactor with a SaveState and avoid duplicate numpy arrays

### DIFF
--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from functools import partial
 from types import FunctionType

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,42 +1,47 @@
 import io
-from pathlib import Path
-from uuid import uuid4
+from typing import Any
 
 import numpy as np
 
 from ._general import function_get_instance
-from ._utils import _import_obj, get_instance, get_module, get_state
+from ._utils import SaveState, _import_obj, get_instance, get_module, get_state
 from .exceptions import UnsupportedTypeException
 
 
-def ndarray_get_state(obj, dst):
+def ndarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
     }
 
-    # First, try to save object with np.save and allow_pickle=False, which
-    # should generally work as long as the dtype is not object.
     try:
-        f_name = f"{uuid4()}.npy"
-        with open(Path(dst) / f_name, "wb") as f:
-            np.save(f, obj, allow_pickle=False)
-        res.update(type="numpy", file=f_name)
+        # If the dtype is object, np.save should not work with
+        # allow_pickle=False, therefore we convert them to a list and
+        # recursively call get_state on it.
+        if obj.dtype == object:
+            obj_serialized = get_state(obj.tolist(), save_state)
+            res["content"] = obj_serialized["content"]
+            res["type"] = "json"
+            res["shape"] = get_state(obj.shape, save_state)
+        else:
+            # Memoize the object and then check if it's file name (containing
+            # the object id) already exists. If it does, there is no need to
+            # save the object again. Memoizitation is necessary since for
+            # ephemeral objects, the same id might otherwise be reused.
+            obj_id = save_state.memoize(obj)
+            f_name = f"{obj_id}.npy"
+            path = save_state.path / f_name
+            if not path.exists():
+                with open(path, "wb") as f:
+                    np.save(f, obj, allow_pickle=False)
+            res.update(type="numpy", file=f_name)
     except ValueError:
-        # Object arrays cannot be saved with allow_pickle=False, therefore we
-        # convert them to a list and recursively call get_state on it. For this,
-        # we expect the dtype to be object.
-        if obj.dtype != object:
-            raise UnsupportedTypeException(
-                f"numpy arrays of dtype {obj.dtype} are not supported yet, please "
-                "open an issue at https://github.com/skops-dev/skops/issues and "
-                "report your error"
-            )
-
-        obj_serialized = get_state(obj.tolist(), dst)
-        res["content"] = obj_serialized["content"]
-        res["type"] = "json"
-        res["shape"] = get_state(obj.shape, dst)
+        # Couldn't save the numpy array with either method
+        raise UnsupportedTypeException(
+            f"numpy arrays of dtype {obj.dtype} are not supported yet, please "
+            "open an issue at https://github.com/skops-dev/skops/issues and "
+            "report your error"
+        )
 
     return res
 
@@ -67,13 +72,13 @@ def ndarray_get_instance(state, src):
     return val
 
 
-def maskedarray_get_state(obj, dst):
+def maskedarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
         "content": {
-            "data": get_state(obj.data, dst),
-            "mask": get_state(obj.mask, dst),
+            "data": get_state(obj.data, save_state),
+            "mask": get_state(obj.mask, save_state),
         },
     }
     return res
@@ -85,8 +90,8 @@ def maskedarray_get_instance(state, src):
     return np.ma.MaskedArray(data, mask)
 
 
-def random_state_get_state(obj, dst):
-    content = get_state(obj.get_state(legacy=False), dst)
+def random_state_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
+    content = get_state(obj.get_state(legacy=False), save_state)
     res = {
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
@@ -103,7 +108,7 @@ def random_state_get_instance(state, src):
     return random_state
 
 
-def random_generator_get_state(obj, dst):
+def random_generator_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     bit_generator_state = obj.bit_generator.state
     res = {
         "__class__": obj.__class__.__name__,
@@ -128,7 +133,7 @@ def random_generator_get_instance(state, src):
 # For numpy.ufunc we need to get the type from the type's module, but for other
 # functions we get it from objet's module directly. Therefore sett a especial
 # get_state method for them here. The load is the same as other functions.
-def ufunc_get_state(obj, dst):
+def ufunc_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,  # ufunc
         "__module__": get_module(type(obj)),  # numpy
@@ -140,14 +145,14 @@ def ufunc_get_state(obj, dst):
     return res
 
 
-def dtype_get_state(obj, dst):
+def dtype_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     # we use numpy's internal save mechanism to store the dtype by
     # saving/loading an empty array with that dtype.
-    tmp = np.ndarray(0, dtype=obj)
+    tmp: np.typing.NDArray = np.ndarray(0, dtype=obj)
     res = {
         "__class__": "dtype",
         "__module__": "numpy",
-        "content": ndarray_get_state(tmp, dst),
+        "content": ndarray_get_state(tmp, save_state),
     }
     return res
 

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from typing import Any
 

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -9,11 +9,7 @@ from zipfile import ZipFile
 
 import skops
 
-from ._utils import _get_instance, _get_state, get_instance, get_state
-
-# For now, there is just one protocol version
-PROTOCOL = 0
-
+from ._utils import SaveState, _get_instance, _get_state, get_instance, get_state
 
 # We load the dispatch functions from the corresponding modules and register
 # them.
@@ -53,9 +49,13 @@ def save(obj, file):
 
     """
     with tempfile.TemporaryDirectory() as dst:
-        with open(Path(dst) / "schema.json", "w") as f:
-            state = get_state(obj, dst)
-            state["protocol"] = PROTOCOL
+        path = Path(dst)
+        with open(path / "schema.json", "w") as f:
+            save_state = SaveState(path=path)
+            state = get_state(obj, save_state)
+            save_state.clear_memo()
+
+            state["protocol"] = save_state.protocol
             state["_skops_version"] = skops.__version__
             json.dump(state, f, indent=2)
 

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from typing import Any
 

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from sklearn.cluster import Birch

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import json  # type: ignore
 import sys


### PR DESCRIPTION
Supersedes #150 

## Description

Previously, we were passing only the directory path, now we pass a `dataclass` that contains the path but also the protocol and a way to memoize objects.

This way, those functions that, for some reason, need to memoize the object, can now do so. This allows us, for instance, to make sure that the same numpy array is not saved multiple times on disk (see discussion in #150).

I went ahead and implemented memoization for numpy arrays (and scipy sparse matrices) in order to ensure that this refactor actually is sufficient to solve the initial problem.

## Design

The design goal here was to make as few code changes as possible while still enabling much greater flexibility. E.g., I wanted to leave the individual `get_state`/`get_instance` methods as they are (except for renaming one of the parameters), since I find the current structure very readable. That's why I didn't go with a giant class with a high number of `get_state`/`get_instance` methods, which is another solution we discussed.

The `SaveState` object can serve a similar purpose as self would have served if we choose a class based approach, i.e. it can hold the state necessary for the functions to perform their work and in the future, we can add more state if necessary.

For the time being, I didn't change the `get_instance` methods at all, even though we could make an analogous change there, passing a `LoadState` instead of `src` everywhere. Let me know if I should make that change for consistency or if we should leave those functions untouched until it becomes necessary.

The memoization part has been modeled to be similar to what pickle does but tailored to our needs.

## Coincidental changes

While working on #150, I discovered a minor bug where trying to store an object numpy array resulted in the creation of a broken `.npy` file being left over. This is because numpy tries to write to the file until it encounters an error and raises, but then doesn't clean up said file. Before this bugfix, we would include that broken file in the zip archive, although we wouldn't do anything with it. Now, no such file is being created. Since #150 won't be merged, I added the bugfix and a corresponding test here.

Moreover, while working on this, since I had to touch the signature of the `get_state` functions, I also added type hints in accordance to the rest of the code base ("light" types).

While working on that, I found that we have a single case where the `get_state` function would not return a dict, namely when the object is a primitive type that can be json-serialized, in which case we return a string. I changed the return type there to always be dict for consistency (so in this case a dict that contains the json-serialized string).