### PR TITLE
TST Refactor test fixture to be more atomic

### DIFF
--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -47,7 +47,7 @@ def iris_estimator(iris_data):
 
 
 @pytest.fixture
-def pkl_file(iris_estimator):
+def iris_pkl_file(iris_estimator):
     pkl_file = tempfile.mkstemp(suffix=".pkl", prefix="skops-test")[1]
     with open(pkl_file, "wb") as f:
         pickle.dump(iris_estimator, f)
@@ -55,7 +55,7 @@ def pkl_file(iris_estimator):
 
 
 @pytest.fixture
-def skops_file(iris_estimator):
+def iris_skops_file(iris_estimator):
     skops_folder = tempfile.mkdtemp()
     model_name = "model.skops"
     skops_path = Path(skops_folder) / model_name
@@ -84,19 +84,19 @@ def _create_model_card_from_saved_model(
 
 @pytest.fixture
 def skops_model_card_metadata_from_config(
-    destination_path, iris_estimator, skops_file, iris_data
+    destination_path, iris_estimator, iris_skops_file, iris_data
 ):
     yield _create_model_card_from_saved_model(
-        destination_path, iris_estimator, iris_data, skops_file
+        destination_path, iris_estimator, iris_data, iris_skops_file
     )
 
 
 @pytest.fixture
 def pkl_model_card_metadata_from_config(
-    destination_path, iris_estimator, pkl_file, iris_data
+    destination_path, iris_estimator, iris_pkl_file, iris_data
 ):
     yield _create_model_card_from_saved_model(
-        destination_path, iris_estimator, iris_data, pkl_file
+        destination_path, iris_estimator, iris_data, iris_pkl_file
     )
 
 

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -34,14 +34,28 @@ def model_card(model_diagram=True):
 
 
 @pytest.fixture
-def model_card_metadata_from_config(destination_path):
+def iris_data():
     X, y = load_iris(return_X_y=True, as_frame=True)
+    yield X, y
+
+
+@pytest.fixture
+def pkl_iris_estimator(iris_data):
+    X, y = iris_data
     est = LogisticRegression(solver="liblinear").fit(X, y)
     pkl_file = tempfile.mkstemp(suffix=".pkl", prefix="skops-test")[1]
     with open(pkl_file, "wb") as f:
         pickle.dump(est, f)
+    yield pkl_file
+
+
+@pytest.fixture
+def model_card_metadata_from_config(destination_path, pkl_iris_estimator, iris_data):
+    X, y = iris_data
+    with open(pkl_iris_estimator, "rb") as f:
+        est = pickle.load(f)
     hub_utils.init(
-        model=pkl_file,
+        model=pkl_iris_estimator,
         requirements=[f"scikit-learn=={sklearn.__version__}"],
         dst=destination_path,
         task="tabular-classification",

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -208,7 +208,6 @@ def test_add_metrics(destination_path, model_card):
 
 def test_code_autogeneration(destination_path, pkl_model_card_metadata_from_config):
     # test if getting started code is automatically generated
-    pkl_model_card_metadata_from_config.save(Path(destination_path) / "README.md")
     metadata = metadata_load(local_path=Path(destination_path) / "README.md")
     filename = metadata["model_file"]
     with open(Path(destination_path) / "README.md") as f:

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -146,6 +146,12 @@ def test_metadata_keys(destination_path, model_card):
     assert "tags: dummy" in model_card
 
 
+def test_default_sections_save(model_card):
+    # test if the plot and hyperparameters are only added during save
+    assert "<style>" not in str(model_card)
+    assert "fit_intercept" not in str(model_card)
+
+
 def test_add_metrics(destination_path, model_card):
     model_card.add_metrics(**{"acc": 0.1})
     model_card.add_metrics(f1=0.1)

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -228,7 +228,6 @@ def test_metadata_from_config_tabular_data(
     pkl_model_card_metadata_from_config, destination_path
 ):
     # test if widget data is correctly set in the README
-    pkl_model_card_metadata_from_config.save(Path(destination_path) / "README.md")
     metadata = metadata_load(local_path=Path(destination_path) / "README.md")
     assert "widget" in metadata
 


### PR DESCRIPTION
Small PR to split the responsibilities of the `model_card_metadata_from_config` fixture to be more atomic, with fixtures that

1) Fetch the Iris data
2) Creates an estimator from the Iris data
3) Pickles estimator in a temp file
4) Create a model card based on other fixtures

Notes:
* Could also now refactor the other places where the iris data is called to use the fixture, or could remove the Iris fetch fetch fixture all together and just call `load_iris` in each fixture.

Should resolve https://github.com/skops-dev/skops/issues/166