### PR TITLE
ENH Add dumps and loads functions

### DIFF
--- a/skops/io/__init__.py
+++ b/skops/io/__init__.py
@@ -1,3 +1,3 @@
-from ._persist import load, save
+from ._persist import dumps, load, loads, save
 
-__all__ = ["load", "save"]
+__all__ = ["dumps", "load", "loads", "save"]

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -28,7 +28,7 @@ def ndarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
         else:
             data_buffer = io.BytesIO()
             np.save(data_buffer, obj)
-            obj_id = save_state.memoize(obj)  # TODO: useless
+            obj_id = save_state.memoize(obj)
             f_name = f"{obj_id}.npy"
             if f_name not in save_state.zip_file.namelist():
                 save_state.zip_file.writestr(f_name, data_buffer.getbuffer())

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -28,6 +28,10 @@ def ndarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
         else:
             data_buffer = io.BytesIO()
             np.save(data_buffer, obj)
+            # Memoize the object and then check if it's file name (containing
+            # the object id) already exists. If it does, there is no need to
+            # save the object again. Memoizitation is necessary since for
+            # ephemeral objects, the same id might otherwise be reused.
             obj_id = save_state.memoize(obj)
             f_name = f"{obj_id}.npy"
             if f_name not in save_state.zip_file.namelist():

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import importlib
 import io
 import json
@@ -33,25 +32,63 @@ def _save(obj):
         state["protocol"] = save_state.protocol
         state["_skops_version"] = skops.__version__
 
-        zip_file.writestr("schema.json", json.dumps(state))
+        zip_file.writestr("schema.json", json.dumps(state, indent=2))
 
     return buffer
 
 
 def dump(obj, file):
+    """Save an object using the skops persistence format.
+
+    Skops aims at providing a secure persistence feature that does not rely on
+    :mod:`pickle`, which is inherently insecure. For more information, please
+    visit the :ref:`persistence` documentation.
+
+    .. warning::
+
+       This feature is very early in development, which means the API is
+       unstable and it is **not secure** at the moment. Therefore, use the same
+       caution as you would for ``pickle``: Don't load from sources that you
+       don't trust. In the future, more security will be added.
+
+    Parameters
+    ----------
+    obj: object
+        The object to be saved. Usually a scikit-learn compatible model.
+
+    file: str
+        The file name. A zip archive will automatically created. As a matter of
+        convention, we recommend to use the ".skops" file extension, e.g.
+        ``save(model, "my-model.skops")``.
+
+    """
     buffer = _save(obj)
     with open(file, "wb") as f:
         f.write(buffer.getbuffer())
 
 
-# TODO
+# TODO: remove "save" in favor of "dump"
 save = dump
 
 
 def dumps(obj):
-    """TODO"""
+    """Save an object uisng the skops persistence format as a bytes object.
+
+    .. warning::
+
+       This feature is very early in development, which means the API is
+       unstable and it is **not secure** at the moment. Therefore, use the same
+       caution as you would for ``pickle``: Don't load from sources that you
+       don't trust. In the future, more security will be added.
+
+    Parameters
+    ----------
+    obj: object
+        The object to be saved. Usually a scikit-learn compatible model.
+
+    """
     buffer = _save(obj)
-    return base64.b64encode(buffer.getbuffer())
+    return buffer.getbuffer().tobytes()
 
 
 def load(file):
@@ -85,12 +122,27 @@ def load(file):
     return instance
 
 
-def loads(s):
-    """TODO"""
-    if isinstance(s, str):
+def loads(data):
+    """Load an object saved with the skops persistence format from a bytes
+    object.
+
+    .. warning::
+
+       This feature is very early in development, which means the API is
+       unstable and it is **not secure** at the moment. Therefore, use the same
+       caution as you would for ``pickle``: Don't load from sources that you
+       don't trust. In the future, more security will be added.
+
+    Parameters
+    ----------
+    data: bytes
+        The file name of the object to be loaded.
+
+    """
+    if isinstance(data, str):
         raise TypeError("Can't load skops format from string, pass bytes")
 
-    with ZipFile(io.BytesIO(base64.b64decode(s)), "r") as zip_file:
+    with ZipFile(io.BytesIO(data), "r") as zip_file:
         schema = json.loads(zip_file.read("schema.json"))
         instance = get_instance(schema, src=zip_file)
     return instance

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -16,6 +16,10 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
 
     data_buffer = io.BytesIO()
     save_npz(data_buffer, obj)
+    # Memoize the object and then check if it's file name (containing
+    # the object id) already exists. If it does, there is no need to
+    # save the object again. Memoizitation is necessary since for
+    # ephemeral objects, the same id might otherwise be reused.
     obj_id = save_state.memoize(obj)
     f_name = f"{obj_id}.npz"
     if f_name not in save_state.zip_file.namelist():

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import io
 from typing import Any
 
@@ -19,7 +18,8 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     save_npz(data_buffer, obj)
     obj_id = save_state.memoize(obj)  # TODO: useless
     f_name = f"{obj_id}.npz"
-    save_state.zip_file.writestr(f_name, data_buffer.getbuffer())
+    if f_name not in save_state.zip_file.namelist():
+        save_state.zip_file.writestr(f_name, data_buffer.getbuffer())
 
     res["type"] = "scipy"
     res["file"] = f_name
@@ -27,13 +27,6 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
 
 
 def sparse_matrix_get_instance(state, src):
-    if state["type"] == "base64":
-        # TODO
-        b64 = state["content"].encode("utf-8")
-        b = io.BytesIO(base64.b64decode(b64))
-        val = load_npz(b)
-        return val
-
     if state["type"] != "scipy":
         raise TypeError(
             f"Cannot load object of type {state['__module__']}.{state['__class__']}"

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import io
 from typing import Any
 
@@ -13,6 +14,16 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
     }
+
+    if save_state.path is None:
+        # using skops.io.dumps, don't write to file
+        f = io.BytesIO()
+        save_npz(f, obj)
+        b = f.getvalue()
+        b64 = base64.b64encode(b)
+        s = b64.decode("utf-8")
+        res.update(content=s, type="base64")
+        return res
 
     # Memoize the object and then check if it's file name (containing the object
     # id) already exists. If it does, there is no need to save the object again.
@@ -30,6 +41,13 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
 
 
 def sparse_matrix_get_instance(state, src):
+    if state["type"] == "base64":
+        # TODO
+        b64 = state["content"].encode("utf-8")
+        b = io.BytesIO(base64.b64decode(b64))
+        val = load_npz(b)
+        return val
+
     if state["type"] != "scipy":
         raise TypeError(
             f"Cannot load object of type {state['__module__']}.{state['__class__']}"

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -16,7 +16,7 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
 
     data_buffer = io.BytesIO()
     save_npz(data_buffer, obj)
-    obj_id = save_state.memoize(obj)  # TODO: useless
+    obj_id = save_state.memoize(obj)
     f_name = f"{obj_id}.npz"
     if f_name not in save_state.zip_file.namelist():
         save_state.zip_file.writestr(f_name, data_buffer.getbuffer())

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -5,9 +5,9 @@ import json  # type: ignore
 import sys
 from dataclasses import dataclass, field
 from functools import _find_impl, get_cache_token, update_wrapper  # type: ignore
-from pathlib import Path
 from types import FunctionType
 from typing import Any
+from zipfile import ZipFile
 
 from skops.utils.fixes import GenericAlias
 
@@ -227,6 +227,7 @@ class SaveState:
 
     Parameters
     ----------
+    TODO
     path: pathlib.Path
         The path to the directory to store the object in.
 
@@ -236,7 +237,7 @@ class SaveState:
 
     """
 
-    path: Path
+    zip_file: ZipFile
     protocol: int = DEFAULT_PROTOCOL
     memo: dict[int, Any] = field(default_factory=dict)
 

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -227,7 +227,9 @@ class SaveState:
 
     Parameters
     ----------
-    TODO
+    zip_file: zipfile.ZipFile
+        The zip file to write the data to, must be in write mode.
+
     path: pathlib.Path
         The path to the directory to store the object in.
 

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -787,3 +787,10 @@ def test_numpy_dtype_object_does_not_store_broken_file(tmp_path):
 
     # this estimator should not have any numpy file
     assert not any(file.endswith(".npy") for file in files)
+
+
+def test_loads_from_str():
+    # loads expects bytes, not str
+    msg = "Can't load skops format from string, pass bytes"
+    with pytest.raises(TypeError, match=msg):
+        loads("this is a string")


### PR DESCRIPTION
Resolves issue #180. Quoting:

It would be nice to have the equivalent of `pickle.dumps` / `pickle.loads` or `json.dumps` / `json.loads` for `skops.save` / `skops.load`. That way, saving and loading does not necessarily require dealing with files. It could also facilitate testing and sending data over the wire.

## Implementation

This is still very much WIP but I wanted to get some early feedback by @skops-dev/maintainers. The idea is to reuse as much code as possible.

The main changes are around saving numpy arrays and sparse matrices, which now have to deal with a third option. The solution I chose involves a rather ugly roundtrip from bytes > base 64 encoded bytes > string and back, since json can't deal with bytes. If there is a better solution, please let me know. Also, since we don't save to file, there is no memoization step involved.

Regarding the tests, I have modified them so that they now run once with `save`/`load` and once with `dumps`/`loads`. This of course doubles the time required to run those tests, so in the future we may only run one setting (`dumps` and `loads`) and then have a handful of tests that specifically test `save`/`load`.