### PR TITLE
CI Use v3 of codecov GitHub action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,7 +54,7 @@ jobs:
       run: mypy --config-file pyproject.toml skops
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         env_vars: OS,PYTHON
         fail_ci_if_error: true


### PR DESCRIPTION
I'm observing a lot of:

> Error: Codecov: Failed to properly upload: The process '/Users/runner/work/_actions/codecov/codecov-action/v2/dist/codecov' failed with exit code 255

recently. Unfortunately, this seems to be a hard to reproduce bug, as it sometimes happens and sometimes not. Reading through some codecov issues:

- https://github.com/codecov/codecov-action/issues/ 837
- https://github.com/codecov/codecov-action/issues/ 598

(remove the space that was added to not spam those issues)

Updating their action to v3 was mentioned as a possible solution.