### PR TITLE
MNT Rename skops.io.save to skops.io.dump

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -30,27 +30,32 @@ the `Python docs
     code during unpickling. Never unpickle data that could have come from an
     untrusted source, or that could have been tampered with.
 
-In contrast to ``pickle``, the :func:`skops.io.save` and :func:`skops.io.load`
+In contrast to ``pickle``, the :func:`skops.io.dump` and :func:`skops.io.load`
 functions cannot be used to save arbitrary Python code, but they bypass
 ``pickle`` and are thus more secure.
 
 Usage
 -----
 
-The code snippet below illustrates how to use :func:`skops.io.save` and
+The code snippet below illustrates how to use :func:`skops.io.dump` and
 :func:`skops.io.load`:
 
 .. code:: python
 
     from sklearn.linear_model import LogisticRegression
-    from skops.io import load, save
+    from skops.io import dump, load
 
     clf = LogisticRegression(random_state=0, solver="liblinear")
     clf.fit(X_train, y_train)
-    save(clf, "my-logistic-regression.skops")
+    dump(clf, "my-logistic-regression.skops")
     # ...
     loaded = load("my-logistic-regression.skops")
     loaded.predict(X_test)
+
+    # in memory
+    from skops.io import dumps, loads
+    serialized = dumps(clf)
+    loaded = loads(serialized)
 
 At the moment, we support the vast majority of sklearn estimators. This includes
 complex use cases such as :class:`sklearn.pipeline.Pipeline`,

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -16,7 +16,7 @@ import skops
 from skops import hub_utils
 from skops.card import Card, metadata_from_config
 from skops.card._model_card import PlotSection, TableSection
-from skops.io import save
+from skops.io import dump
 
 
 def fit_model():
@@ -59,7 +59,7 @@ def iris_skops_file(iris_estimator):
     skops_folder = tempfile.mkdtemp()
     model_name = "model.skops"
     skops_path = Path(skops_folder) / model_name
-    save(iris_estimator, skops_path)
+    dump(iris_estimator, skops_path)
     yield skops_path
 
 

--- a/skops/io/__init__.py
+++ b/skops/io/__init__.py
@@ -1,3 +1,3 @@
-from ._persist import dumps, load, loads, save
+from ._persist import dump, dumps, load, loads
 
-__all__ = ["dumps", "load", "loads", "save"]
+__all__ = ["dumps", "load", "loads", "dump"]

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -67,10 +67,6 @@ def dump(obj, file):
         f.write(buffer.getbuffer())
 
 
-# TODO: remove "save" in favor of "dump"
-save = dump
-
-
 def dumps(obj):
     """Save an object uisng the skops persistence format as a bytes object.
 

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -50,7 +50,7 @@ from sklearn.utils.estimator_checks import (
 )
 
 import skops
-from skops.io import dumps, load, loads, save
+from skops.io import dump, dumps, load, loads
 from skops.io._sklearn import UNSUPPORTED_TYPES
 from skops.io._utils import _get_instance, _get_state
 from skops.io.exceptions import UnsupportedTypeException
@@ -127,7 +127,7 @@ def save_load_round(estimator, f_name, dump_method="fs"):
     if dump_method == "memory":
         return loads(dumps(estimator))
 
-    save(file=f_name, obj=estimator)
+    dump(file=f_name, obj=estimator)
     loaded = load(file=f_name)
     return loaded
 
@@ -672,7 +672,7 @@ def test_metainfo(tmp_path):
     # safe and load the schema
     estimator = MyEstimator().fit(None)
     f_name = tmp_path / "file.skops"
-    save(file=f_name, obj=estimator)
+    dump(file=f_name, obj=estimator)
     schema = json.loads(ZipFile(f_name).read("schema.json"))
 
     # check some schema metainfo


### PR DESCRIPTION
As discussed in #182.

Also added a small snippet to docs about using `dumps` and `loads`.