### PR TITLE
ENH Implement LoadContext to handle multiple instances

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -236,16 +236,16 @@ class Card:
     ... )
     >>> disp.plot()
     <sklearn.metrics._plot.confusion_matrix.ConfusionMatrixDisplay object at ...>
-    >>> disp.figure_.savefig("confusion_matrix.png")
+    >>> tmp_path = Path(tempfile.mkdtemp(prefix="skops-"))
+    >>> disp.figure_.savefig(tmp_path / "confusion_matrix.png")
     ...
     >>> model_card.add_plot(confusion_matrix="confusion_matrix.png")
     Card(
       model=LogisticRegression(random_state=0, solver='liblinear'),
       metadata.license=mit,
-      confusion_matrix='confusion_matrix.png',
+      confusion_matrix='...confusion_matrix.png',
     )
-    >>> with tempfile.TemporaryDirectory() as tmpdir:
-    ...     model_card.save((Path(tmpdir) / "README.md"))
+    >>> model_card.save(tmp_path / "README.md")
     """
 
     def __init__(

--- a/skops/io/_dispatch.py
+++ b/skops/io/_dispatch.py
@@ -13,6 +13,7 @@ def get_instance(state, load_state: LoadState):
         return json.loads(state["content"])
 
     saved_id = state.get("__id__")
+
     if saved_id and saved_id in load_state.memo:
         # an instance has already been loaded, just return the loaded instance
         return load_state.get_instance(saved_id)

--- a/skops/io/_dispatch.py
+++ b/skops/io/_dispatch.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import json
 
+from skops.io._utils import LoadState
+
 GET_INSTANCE_MAPPING = {}  # type: ignore
 
 
-def get_instance(state, src):
+def get_instance(state, load_state: LoadState):
     """Create instance based on the state, using json if possible"""
     if state.get("is_json"):
         return json.loads(state["content"])
+
+    saved_id = state.get("__id__")
+    if saved_id and saved_id in load_state.memo:
+        # an instance has already been loaded, just return the loaded instance
+        return load_state.get_instance(saved_id)
 
     try:
         get_instance_func = GET_INSTANCE_MAPPING[state["__loader__"]]
@@ -17,4 +24,11 @@ def get_instance(state, src):
         raise TypeError(
             f" Can't find loader {state['__loader__']} for type {type_name}."
         )
-    return get_instance_func(state, src)
+
+    loaded_obj = get_instance_func(state, load_state)
+
+    # hold reference to obj in case same instance encountered again in save state
+    if saved_id:
+        load_state.memoize(loaded_obj, saved_id)
+
+    return loaded_obj

--- a/skops/io/_dispatch.py
+++ b/skops/io/_dispatch.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import json
 
-from skops.io._utils import LoadState
+from skops.io._utils import LoadContext
 
 GET_INSTANCE_MAPPING = {}  # type: ignore
 
 
-def get_instance(state, load_state: LoadState):
+def get_instance(state, load_context: LoadContext):
     """Create instance based on the state, using json if possible"""
 
     saved_id = state.get("__id__")
-    if saved_id in load_state.memo:
+    if saved_id in load_context.memo:
         # an instance has already been loaded, just return the loaded instance
-        return load_state.get_instance(saved_id)
+        return load_context.get_instance(saved_id)
 
     if state.get("is_json"):
         loaded_obj = json.loads(state["content"])
@@ -26,10 +26,10 @@ def get_instance(state, load_state: LoadState):
                 f" Can't find loader {state['__loader__']} for type {type_name}."
             )
 
-        loaded_obj = get_instance_func(state, load_state)
+        loaded_obj = get_instance_func(state, load_context)
 
     # hold reference to obj in case same instance encountered again in save state
     if saved_id:
-        load_state.memoize(loaded_obj, saved_id)
+        load_context.memoize(loaded_obj, saved_id)
 
     return loaded_obj

--- a/skops/io/_dispatch.py
+++ b/skops/io/_dispatch.py
@@ -11,7 +11,7 @@ def get_instance(state, load_state: LoadState):
     """Create instance based on the state, using json if possible"""
 
     saved_id = state.get("__id__")
-    if saved_id and saved_id in load_state.memo:
+    if saved_id in load_state.memo:
         # an instance has already been loaded, just return the loaded instance
         return load_state.get_instance(saved_id)
 

--- a/skops/io/_dispatch.py
+++ b/skops/io/_dispatch.py
@@ -9,24 +9,24 @@ GET_INSTANCE_MAPPING = {}  # type: ignore
 
 def get_instance(state, load_state: LoadState):
     """Create instance based on the state, using json if possible"""
-    if state.get("is_json"):
-        return json.loads(state["content"])
 
     saved_id = state.get("__id__")
-
     if saved_id and saved_id in load_state.memo:
         # an instance has already been loaded, just return the loaded instance
         return load_state.get_instance(saved_id)
 
-    try:
-        get_instance_func = GET_INSTANCE_MAPPING[state["__loader__"]]
-    except KeyError:
-        type_name = f"{state['__module__']}.{state['__class__']}"
-        raise TypeError(
-            f" Can't find loader {state['__loader__']} for type {type_name}."
-        )
+    if state.get("is_json"):
+        loaded_obj = json.loads(state["content"])
+    else:
+        try:
+            get_instance_func = GET_INSTANCE_MAPPING[state["__loader__"]]
+        except KeyError:
+            type_name = f"{state['__module__']}.{state['__class__']}"
+            raise TypeError(
+                f" Can't find loader {state['__loader__']} for type {type_name}."
+            )
 
-    loaded_obj = get_instance_func(state, load_state)
+        loaded_obj = get_instance_func(state, load_state)
 
     # hold reference to obj in case same instance encountered again in save state
     if saved_id:

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -8,19 +8,10 @@ from typing import Any
 import numpy as np
 
 from ._dispatch import get_instance
-from ._utils import (
-    LoadState,
-    SaveState,
-    _import_obj,
-    get_module,
-    get_state,
-    gettype,
-    persist_id,
-)
+from ._utils import LoadState, SaveState, _import_obj, get_module, get_state, gettype
 from .exceptions import UnsupportedTypeException
 
 
-@persist_id
 def dict_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -70,7 +61,6 @@ def list_get_instance(state, load_state: LoadState):
     return content
 
 
-@persist_id
 def tuple_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -103,7 +93,6 @@ def tuple_get_instance(state, load_state: LoadState):
     return content
 
 
-@persist_id
 def function_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -122,7 +111,6 @@ def function_get_instance(state, load_state: LoadState):
     return loaded
 
 
-@persist_id
 def partial_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     _, _, (func, args, kwds, namespace) = obj.__reduce__()
     res = {
@@ -170,7 +158,6 @@ def type_get_instance(state, load_state: LoadState):
     return loaded
 
 
-@persist_id
 def slice_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -192,7 +179,6 @@ def slice_get_instance(state, load_state: LoadState):
     return slice(start, stop, step)
 
 
-@persist_id
 def object_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     # This method is for objects which can either be persisted with json, or
     # the ones for which we can get/set attributes through
@@ -256,7 +242,6 @@ def object_get_instance(state, load_state: LoadState):
     return instance
 
 
-@persist_id
 def method_get_state(obj: Any, save_state: SaveState):
     # This method is used to persist bound methods, which are
     # dependent on a specific instance of an object.

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -98,6 +98,7 @@ def function_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
         "__class__": obj.__class__.__name__,
         "__module__": get_module(obj),
         "__loader__": "function_get_instance",
+        "__id__": id(obj),
         "content": {
             "module_path": get_module(obj),
             "function": obj.__name__,
@@ -192,6 +193,7 @@ def object_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
             "__loader__": "none",
             "content": obj_str,
             "is_json": True,
+            "__id__": id(obj),
         }
     except Exception:
         pass
@@ -200,6 +202,7 @@ def object_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
         "__class__": obj.__class__.__name__,
         "__module__": get_module(type(obj)),
         "__loader__": "object_get_instance",
+        "__id__": id(obj),
     }
 
     # __getstate__ takes priority over __dict__, and if non exist, we only save
@@ -251,17 +254,17 @@ def method_get_state(obj: Any, save_state: SaveState):
         "__class__": obj.__class__.__name__,
         "__module__": get_module(obj),
         "__loader__": "method_get_instance",
+        "__id__": id(obj),
         "content": {
             "func": obj.__func__.__name__,
             "obj": get_state(obj.__self__, save_state),
         },
     }
-
     return res
 
 
 def method_get_instance(state, load_state: LoadState):
-    loaded_obj = object_get_instance(state["content"]["obj"], load_state)
+    loaded_obj = get_instance(state["content"]["obj"], load_state)
     method = getattr(loaded_obj, state["content"]["func"])
     return method
 

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ._dispatch import get_instance
 from ._general import function_get_instance
-from ._utils import LoadState, SaveState, _import_obj, get_module, get_state
+from ._utils import LoadState, SaveState, _import_obj, get_module, get_state, persist_id
 from .exceptions import UnsupportedTypeException
 
 
@@ -78,6 +78,7 @@ def ndarray_get_instance(state, load_state: LoadState):
     return val
 
 
+@persist_id
 def maskedarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -97,6 +98,7 @@ def maskedarray_get_instance(state, load_state: LoadState):
     return np.ma.MaskedArray(data, mask)
 
 
+@persist_id
 def random_state_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     content = get_state(obj.get_state(legacy=False), save_state)
     res = {
@@ -116,6 +118,7 @@ def random_state_get_instance(state, load_state: LoadState):
     return random_state
 
 
+@persist_id
 def random_generator_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     bit_generator_state = obj.bit_generator.state
     res = {
@@ -142,6 +145,7 @@ def random_generator_get_instance(state, load_state: LoadState):
 # For numpy.ufunc we need to get the type from the type's module, but for other
 # functions we get it from objet's module directly. Therefore sett a especial
 # get_state method for them here. The load is the same as other functions.
+@persist_id
 def ufunc_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,  # ufunc
@@ -155,6 +159,7 @@ def ufunc_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return res
 
 
+@persist_id
 def dtype_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     # we use numpy's internal save mechanism to store the dtype by
     # saving/loading an empty array with that dtype.

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ._dispatch import get_instance
 from ._general import function_get_instance
-from ._utils import LoadState, SaveState, _import_obj, get_module, get_state, persist_id
+from ._utils import LoadState, SaveState, _import_obj, get_module, get_state
 from .exceptions import UnsupportedTypeException
 
 
@@ -78,7 +78,6 @@ def ndarray_get_instance(state, load_state: LoadState):
     return val
 
 
-@persist_id
 def maskedarray_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,
@@ -98,7 +97,6 @@ def maskedarray_get_instance(state, load_state: LoadState):
     return np.ma.MaskedArray(data, mask)
 
 
-@persist_id
 def random_state_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     content = get_state(obj.get_state(legacy=False), save_state)
     res = {
@@ -118,7 +116,6 @@ def random_state_get_instance(state, load_state: LoadState):
     return random_state
 
 
-@persist_id
 def random_generator_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     bit_generator_state = obj.bit_generator.state
     res = {
@@ -145,7 +142,6 @@ def random_generator_get_instance(state, load_state: LoadState):
 # For numpy.ufunc we need to get the type from the type's module, but for other
 # functions we get it from objet's module directly. Therefore sett a especial
 # get_state method for them here. The load is the same as other functions.
-@persist_id
 def ufunc_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     res = {
         "__class__": obj.__class__.__name__,  # ufunc
@@ -159,7 +155,6 @@ def ufunc_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return res
 
 
-@persist_id
 def dtype_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     # we use numpy's internal save mechanism to store the dtype by
     # saving/loading an empty array with that dtype.

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -116,7 +116,6 @@ def load(file):
         schema = json.loads(input_zip.read("schema.json"))
         load_state = LoadState(src=input_zip)
         instance = get_instance(schema, load_state=load_state)
-        load_state.clear_memo()
     return instance
 
 
@@ -144,5 +143,4 @@ def loads(data):
         schema = json.loads(input_zip.read("schema.json"))
         load_state = LoadState(src=input_zip)
         instance = get_instance(schema, load_state=load_state)
-        load_state.clear_memo()
     return instance

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import skops
 
 from ._dispatch import GET_INSTANCE_MAPPING, get_instance
-from ._utils import LoadState, SaveState, _get_state, get_state
+from ._utils import LoadContext, SaveContext, _get_state, get_state
 
 # We load the dispatch functions from the corresponding modules and register
 # them.
@@ -26,11 +26,11 @@ def _save(obj):
     buffer = io.BytesIO()
 
     with ZipFile(buffer, "w") as zip_file:
-        save_state = SaveState(zip_file=zip_file)
-        state = get_state(obj, save_state)
-        save_state.clear_memo()
+        save_context = SaveContext(zip_file=zip_file)
+        state = get_state(obj, save_context)
+        save_context.clear_memo()
 
-        state["protocol"] = save_state.protocol
+        state["protocol"] = save_context.protocol
         state["_skops_version"] = skops.__version__
         zip_file.writestr("schema.json", json.dumps(state, indent=2))
 
@@ -114,8 +114,8 @@ def load(file):
     """
     with ZipFile(file, "r") as input_zip:
         schema = json.loads(input_zip.read("schema.json"))
-        load_state = LoadState(src=input_zip)
-        instance = get_instance(schema, load_state=load_state)
+        load_context = LoadContext(src=input_zip)
+        instance = get_instance(schema, load_context=load_context)
     return instance
 
 
@@ -141,6 +141,6 @@ def loads(data):
 
     with ZipFile(io.BytesIO(data), "r") as input_zip:
         schema = json.loads(input_zip.read("schema.json"))
-        load_state = LoadState(src=input_zip)
-        instance = get_instance(schema, load_state=load_state)
+        load_context = LoadContext(src=input_zip)
+        instance = get_instance(schema, load_context=load_context)
     return instance

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -32,7 +32,6 @@ def _save(obj):
 
         state["protocol"] = save_state.protocol
         state["_skops_version"] = skops.__version__
-
         zip_file.writestr("schema.json", json.dumps(state, indent=2))
 
     return buffer
@@ -117,6 +116,7 @@ def load(file):
         schema = json.loads(input_zip.read("schema.json"))
         load_state = LoadState(src=input_zip)
         instance = get_instance(schema, load_state=load_state)
+        load_state.clear_memo()
     return instance
 
 
@@ -144,4 +144,5 @@ def loads(data):
         schema = json.loads(input_zip.read("schema.json"))
         load_state = LoadState(src=input_zip)
         instance = get_instance(schema, load_state=load_state)
+        load_state.clear_memo()
     return instance

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import skops
 
 from ._dispatch import GET_INSTANCE_MAPPING, get_instance
-from ._utils import SaveState, _get_state, get_state
+from ._utils import LoadState, SaveState, _get_state, get_state
 
 # We load the dispatch functions from the corresponding modules and register
 # them.
@@ -114,8 +114,9 @@ def load(file):
 
     """
     with ZipFile(file, "r") as input_zip:
-        schema = input_zip.read("schema.json")
-        instance = get_instance(json.loads(schema), input_zip)
+        schema = json.loads(input_zip.read("schema.json"))
+        load_state = LoadState(src=input_zip)
+        instance = get_instance(schema, load_state=load_state)
     return instance
 
 
@@ -139,7 +140,8 @@ def loads(data):
     if isinstance(data, str):
         raise TypeError("Can't load skops format from string, pass bytes")
 
-    with ZipFile(io.BytesIO(data), "r") as zip_file:
-        schema = json.loads(zip_file.read("schema.json"))
-        instance = get_instance(schema, src=zip_file)
+    with ZipFile(io.BytesIO(data), "r") as input_zip:
+        schema = json.loads(input_zip.read("schema.json"))
+        load_state = LoadState(src=input_zip)
+        instance = get_instance(schema, load_state=load_state)
     return instance

--- a/skops/io/_scipy.py
+++ b/skops/io/_scipy.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from scipy.sparse import load_npz, save_npz, spmatrix
 
-from ._utils import SaveState, get_module
+from ._utils import LoadState, SaveState, get_module
 
 
 def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
@@ -31,7 +31,7 @@ def sparse_matrix_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return res
 
 
-def sparse_matrix_get_instance(state, src):
+def sparse_matrix_get_instance(state, load_state: LoadState):
     if state["type"] != "scipy":
         raise TypeError(
             f"Cannot load object of type {state['__module__']}.{state['__class__']}"
@@ -39,7 +39,7 @@ def sparse_matrix_get_instance(state, src):
 
     # scipy load_npz uses numpy.save with allow_pickle=False under the hood, so
     # we're safe using it
-    val = load_npz(io.BytesIO(src.read(state["file"])))
+    val = load_npz(io.BytesIO(load_state.src.read(state["file"])))
     return val
 
 

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -87,12 +87,12 @@ def reduce_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return res
 
 
-def reduce_get_instance(state, src, constructor):
+def reduce_get_instance(state, load_state, constructor):
     reduce = state["__reduce__"]
-    args = get_instance(reduce["args"], src)
+    args = get_instance(reduce["args"], load_state)
     instance = constructor(*args)
 
-    attrs = get_instance(state["content"], src)
+    attrs = get_instance(state["content"], load_state)
     if not attrs:
         # nothing more to do
         return instance
@@ -116,8 +116,8 @@ def tree_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return state
 
 
-def tree_get_instance(state, src):
-    return reduce_get_instance(state, src, constructor=Tree)
+def tree_get_instance(state, load_state):
+    return reduce_get_instance(state, load_state, constructor=Tree)
 
 
 def sgd_loss_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
@@ -126,11 +126,11 @@ def sgd_loss_get_state(obj: Any, save_state: SaveState) -> dict[str, Any]:
     return state
 
 
-def sgd_loss_get_instance(state, src):
+def sgd_loss_get_instance(state, load_state):
     cls = gettype(state)
     if cls not in ALLOWED_SGD_LOSSES:
         raise UnsupportedTypeException(f"Expected LossFunction, got {cls}")
-    return reduce_get_instance(state, src, constructor=cls)
+    return reduce_get_instance(state, load_state, constructor=cls)
 
 
 # TODO: remove once support for sklearn<1.2 is dropped.
@@ -152,11 +152,11 @@ def _DictWithDeprecatedKeys_get_state(
 
 
 # TODO: remove once support for sklearn<1.2 is dropped.
-def _DictWithDeprecatedKeys_get_instance(state, src):
+def _DictWithDeprecatedKeys_get_instance(state, load_state):
     # _DictWithDeprecatedKeys is just a wrapper for dict
-    content = dict_get_instance(state["content"]["main"], src)
+    content = dict_get_instance(state["content"]["main"], load_state)
     deprecated_key_to_new_key = dict_get_instance(
-        state["content"]["_deprecated_key_to_new_key"], src
+        state["content"]["_deprecated_key_to_new_key"], load_state
     )
     res = _DictWithDeprecatedKeys(**content)
     res._deprecated_key_to_new_key = deprecated_key_to_new_key

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -94,7 +94,7 @@ def persist_id(func):
     Intended to be used as a decorator.
 
     NB: Not all get_state functions should include ids. Ephemeral objects
-    have their IDs reused, and so storing some objects (like dicts, lists, arrays
+    have their IDs reused, and so storing some objects (some dicts, lists, arrays
     etc.) can cause problems.
     """
 
@@ -165,9 +165,6 @@ class LoadState:
 
     def get_instance(self, id: int) -> Any:
         return self.memo.get(id)
-
-    def clear_memo(self):
-        self.memo.clear()
 
 
 @singledispatch

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -158,14 +158,14 @@ def get_state(value, save_state):
     # fails with `get_state`, we try with json.dumps, if that fails, we raise
     # the original error alongside the json error.
     __id__ = save_state.memoize(obj=value)
+
     try:
         res = _get_state(value, save_state)
-        res["__id__"] = __id__
-        return res
     except TypeError as e1:
         try:
             res = json.dumps(value)
-            res["__id__"] = __id__
-            return res
         except Exception as e2:
             raise e1 from e2
+
+    res["__id__"] = __id__
+    return res

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -89,9 +89,9 @@ DEFAULT_PROTOCOL = 0
 
 @dataclass(frozen=True)
 class SaveContext:
-    """State required for saving the objects
+    """Context required for saving the objects
 
-    This state is passed to each ``get_state_*`` function.
+    This context is passed to each ``get_state_*`` function.
 
     Parameters
     ----------
@@ -124,9 +124,9 @@ class SaveContext:
 
 @dataclass(frozen=True)
 class LoadContext:
-    """State required for loading an object
+    """Context required for loading an object
 
-    This state is passed to each ``get_instance_*`` function.
+    This context is passed to each ``get_instance_*`` function.
 
     Parameters
     ----------

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -88,7 +88,7 @@ DEFAULT_PROTOCOL = 0
 
 
 @dataclass(frozen=True)
-class SaveState:
+class SaveContext:
     """State required for saving the objects
 
     This state is passed to each ``get_state_*`` function.
@@ -123,7 +123,7 @@ class SaveState:
 
 
 @dataclass(frozen=True)
-class LoadState:
+class LoadContext:
     """State required for loading an object
 
     This state is passed to each ``get_instance_*`` function.
@@ -146,21 +146,21 @@ class LoadState:
 
 
 @singledispatch
-def _get_state(obj, save_state):
+def _get_state(obj, save_context):
     # This function should never be called directly. Instead, it is used to
     # dispatch to the correct implementation of get_state for the given type of
     # its first argument.
     raise TypeError(f"Getting the state of type {type(obj)} is not supported yet")
 
 
-def get_state(value, save_state):
+def get_state(value, save_context):
     # This is a helper function to try to get the state of an object. If it
     # fails with `get_state`, we try with json.dumps, if that fails, we raise
     # the original error alongside the json error.
-    __id__ = save_state.memoize(obj=value)
+    __id__ = save_context.memoize(obj=value)
 
     try:
-        res = _get_state(value, save_state)
+        res = _get_state(value, save_context)
     except TypeError as e1:
         try:
             res = json.dumps(value)

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -157,13 +157,15 @@ def get_state(value, save_state):
     # This is a helper function to try to get the state of an object. If it
     # fails with `get_state`, we try with json.dumps, if that fails, we raise
     # the original error alongside the json error.
+    __id__ = save_state.memoize(obj=value)
     try:
         res = _get_state(value, save_state)
-        __id__ = save_state.memoize(obj=value)
         res["__id__"] = __id__
         return res
     except TypeError as e1:
         try:
-            return json.dumps(value)
+            res = json.dumps(value)
+            res["__id__"] = __id__
+            return res
         except Exception as e2:
             raise e1 from e2

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -158,8 +158,8 @@ def get_state(value, save_state):
     # fails with `get_state`, we try with json.dumps, if that fails, we raise
     # the original error alongside the json error.
     try:
-        __id__ = save_state.memoize(obj=value)
         res = _get_state(value, save_state)
+        __id__ = save_state.memoize(obj=value)
         res["__id__"] = __id__
         return res
     except TypeError as e1:

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -87,6 +87,25 @@ def get_module(obj):
 DEFAULT_PROTOCOL = 0
 
 
+def persist_id(func):
+    """Wrapper to add __id__ to states we want to be able to persist as single
+    instances.
+
+    Intended to be used as a decorator.
+
+    NB: Not all get_state functions should include ids. Ephemeral objects
+    have their IDs reused, and so storing some objects (like dicts, lists, arrays
+    etc.) can cause problems.
+    """
+
+    def wrapper(obj: Any, save_state: SaveState):
+        result = func(obj, save_state)
+        result["__id__"] = id(obj)
+        return result
+
+    return wrapper
+
+
 @dataclass(frozen=True)
 class SaveState:
     """State required for saving the objects
@@ -146,6 +165,9 @@ class LoadState:
 
     def get_instance(self, id: int) -> Any:
         return self.memo.get(id)
+
+    def clear_memo(self):
+        self.memo.clear()
 
 
 @singledispatch

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -132,7 +132,6 @@ class LoadContext:
     ----------
     src: zipfile.ZipFile
         The zip file the target object is saved in
-
     """
 
     src: ZipFile

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -125,6 +125,29 @@ class SaveState:
         self.memo.clear()
 
 
+@dataclass(frozen=True)
+class LoadState:
+    """State required for loading an object
+
+    This state is passed to each ``get_instance_*`` function.
+
+    Parameters
+    ----------
+    src: zipfile.ZipFile
+        The zip file the target object is saved in
+
+    """
+
+    src: ZipFile
+    memo: dict[int, Any] = field(default_factory=dict)
+
+    def memoize(self, obj: Any, id: int) -> None:
+        self.memo[id] = obj
+
+    def get_instance(self, id: int) -> Any:
+        return self.memo.get(id)
+
+
 @singledispatch
 def _get_state(obj, save_state):
     # This function should never be called directly. Instead, it is used to

--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -5,7 +5,6 @@ import json  # type: ignore
 import sys
 from dataclasses import dataclass, field
 from functools import singledispatch
-from types import FunctionType
 from typing import Any
 from zipfile import ZipFile
 
@@ -61,10 +60,6 @@ def _import_obj(module, cls_or_func, package=None):
 
 def gettype(state):
     if "__module__" in state and "__class__" in state:
-        if state["__class__"] == "function":
-            # This special case is due to how functions are serialized. We
-            # could try to change it.
-            return FunctionType
         return _import_obj(state["__module__"], state["__class__"])
     return None
 

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -56,7 +56,7 @@ import skops
 from skops.io import dump, dumps, load, loads
 from skops.io._dispatch import GET_INSTANCE_MAPPING, get_instance
 from skops.io._sklearn import UNSUPPORTED_TYPES
-from skops.io._utils import _get_state, get_state
+from skops.io._utils import LoadState, _get_state, get_state
 from skops.io.exceptions import UnsupportedTypeException
 
 # Default settings for X
@@ -96,16 +96,16 @@ def debug_dispatch_functions():
     def debug_get_instance(func):
         # check consistency of argument names and input type
         signature = inspect.signature(func)
-        assert list(signature.parameters.keys()) == ["state", "src"]
+        assert list(signature.parameters.keys()) == ["state", "load_state"]
 
         @wraps(func)
-        def wrapper(state, src):
+        def wrapper(state, load_state):
             assert "__class__" in state
             assert "__module__" in state
             assert "__loader__" in state
-            assert isinstance(src, ZipFile)
+            assert isinstance(load_state, LoadState)
 
-            result = func(state, src)
+            result = func(state, load_state)
             return result
 
         return wrapper

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -972,7 +972,7 @@ def test_disk_and_memory_are_identical(tmp_path):
     ],
 )
 def test_when_given_object_referenced_twice_loads_as_one_object(obj):
-    some_thing = {"obj_1": obj, "obj_2": obj}
-    persisted_thing = loads(dumps(some_thing))
+    an_object = {"obj_1": obj, "obj_2": obj}
+    persisted_object = loads(dumps(an_object))
 
-    assert persisted_thing["obj_1"] is persisted_thing["obj_2"]
+    assert persisted_object["obj_1"] is persisted_object["obj_2"]

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -88,7 +88,7 @@ def debug_dispatch_functions():
             assert "__class__" in result
             assert "__module__" in result
             assert "__loader__" in result
-
+            assert "__id__" in result
             return result
 
         return wrapper
@@ -103,6 +103,7 @@ def debug_dispatch_functions():
             assert "__class__" in state
             assert "__module__" in state
             assert "__loader__" in state
+            assert "__id__" in state
             assert isinstance(load_state, LoadState)
 
             result = func(state, load_state)

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -959,3 +959,12 @@ def test_disk_and_memory_are_identical(tmp_path):
     loaded_memory = loads(dumps(estimator))
 
     assert joblib.hash(loaded_disk) == joblib.hash(loaded_memory)
+
+
+def test_when_given_object_referenced_twice_loads_as_one_object():
+    some_function = np.array([1, 2]).shape
+
+    transformer = FunctionTransformer(func=some_function, inverse_func=some_function)
+    loaded_transformer = loads(dumps(transformer))
+
+    assert loaded_transformer.func is loaded_transformer.inverse_func

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -56,7 +56,7 @@ import skops
 from skops.io import dump, dumps, load, loads
 from skops.io._dispatch import GET_INSTANCE_MAPPING, get_instance
 from skops.io._sklearn import UNSUPPORTED_TYPES
-from skops.io._utils import LoadState, _get_state, get_state
+from skops.io._utils import LoadState, SaveState, _get_state, get_state
 from skops.io.exceptions import UnsupportedTypeException
 
 # Default settings for X
@@ -785,7 +785,9 @@ def test_loads_from_str():
 
 
 def test_get_instance_unknown_type_error_msg():
-    state = get_state(("hi", [123]), None)
+    val = ("hi", [123])
+    save_state = SaveState(None)
+    state = get_state(val, save_state)
     state["__loader__"] = "this_get_instance_does_not_exist"
     msg = "Can't find loader this_get_instance_does_not_exist for type builtins.tuple."
     with pytest.raises(TypeError, match=msg):

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -961,10 +961,18 @@ def test_disk_and_memory_are_identical(tmp_path):
     assert joblib.hash(loaded_disk) == joblib.hash(loaded_memory)
 
 
-def test_when_given_object_referenced_twice_loads_as_one_object():
-    some_function = np.array([1, 2]).shape
+@pytest.mark.parametrize(
+    "obj",
+    [
+        np.array([1, 2]),
+        [1, 2, 3],
+        {1: 1, 2: 2},
+        {1, 2, 3},
+        np.random.RandomState(42),
+    ],
+)
+def test_when_given_object_referenced_twice_loads_as_one_object(obj):
+    some_thing = {"obj_1": obj, "obj_2": obj}
+    persisted_thing = loads(dumps(some_thing))
 
-    transformer = FunctionTransformer(func=some_function, inverse_func=some_function)
-    loaded_transformer = loads(dumps(transformer))
-
-    assert loaded_transformer.func is loaded_transformer.inverse_func
+    assert persisted_thing["obj_1"] is persisted_thing["obj_2"]

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -789,7 +789,7 @@ def test_get_instance_unknown_type_error_msg():
     state["__loader__"] = "this_get_instance_does_not_exist"
     msg = "Can't find loader this_get_instance_does_not_exist for type builtins.tuple."
     with pytest.raises(TypeError, match=msg):
-        get_instance(state, None)
+        get_instance(state, LoadState(None))
 
 
 class _BoundMethodHolder:

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -867,9 +867,6 @@ class TestPersistingBoundMethods:
         self.assert_transformer_persisted_correctly(loaded_transformer, transformer)
         self.assert_bound_method_holder_persisted_correctly(obj, loaded_obj)
 
-    @pytest.mark.xfail(
-        reason="Can't load an object as a single instance if referenced multiple times"
-    )
     def test_works_when_given_multiple_bound_methods_attached_to_single_instance(self):
         obj = _BoundMethodHolder(object_state="")
 

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -968,6 +968,7 @@ def test_disk_and_memory_are_identical(tmp_path):
         [1, 2, 3],
         {1: 1, 2: 2},
         {1, 2, 3},
+        "A string",
         np.random.RandomState(42),
     ],
 )


### PR DESCRIPTION
Fixes #206.

PR to add ability to persist a single instance that is referenced in multiple places.

Notes:
1) Currently, this *does* save the state of the object multiple times, but only initialises once. This is done due to the issue discussed in #195 around not knowing which instance will be loaded first, particularly in complex cases with interwoven dependencies.

2) ~~At the moment, I've only added `__id__` in the places needed to solve the xfail test, but if others are happy with how this looks I will expand this to other `get_state_*` methods :)~~ This is now global, done at the high level `get_state` and `get_instance` functions so works for all types.


----

Regarding 1:  I looked into any ways to store DAGs in JSON and bumped into [a relatively new addition to JSON syntax, JSON-LD](https://www.w3.org/TR/json-ld/), which also happens to [have a Python implementation](https://github.com/digitalbazaar/pyld). I feel like if we want to only save these objects once, we would need some kind of DAG implementation to hold dependencies. This, however, would need a major rework and feels like it might be overkill for the time being, but it's worth holding in mind.