### PR TITLE
DOC The "path" parameter doesn't exist

### DIFF
--- a/skops/io/_utils.py
+++ b/skops/io/_utils.py
@@ -98,9 +98,6 @@ class SaveState:
     zip_file: zipfile.ZipFile
         The zip file to write the data to, must be in write mode.
 
-    path: pathlib.Path
-        The path to the directory to store the object in.
-
     protocol: int
         The protocol of the persistence format. Right now, there is only
         protocol 0, but this leaves the door open for future changes.


### PR DESCRIPTION
A small one :) @skops-dev/maintainers 