### PR TITLE
CI Skip inference tests by default

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,20 @@ jobs:
     timeout-minutes: 15
 
     steps:
+
+    # The following two steps are workarounds to retrieve the "real" commit
+    # message and make it available in later steps. This is because we want to
+    # check the content of the commit message, but on PRs, it's replaced by an
+    # artificial commit message. See https://github.com/skops-dev/skops/pull/147
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{github.event.after}}
+
+    # - run: |
+    #     echo PR_COMMIT_MESSAGE=$(git log -1 --pretty=format:\"%s\") >> $GITHUB_ENV
+    #   shell: bash
+
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v3
       with:
@@ -63,10 +76,16 @@ jobs:
       env:
         SUPER_SECRET: ${{ secrets.HF_HUB_TOKEN }}
       run: |
-        python -m pytest -s -v --cov-report=xml skops/
+        python -m pytest -s -v --cov-report=xml -m "not inference" skops/
 
     - name: Mypy
       run: mypy --config-file pyproject.toml skops
+
+    - name: Inference tests (conditional)
+      # if: contains(env.PR_COMMIT_MESSAGE, '[CI inference]')
+      if: contains(github.event.head_commit.message, '[CI inference]')
+      run: |
+        python -m pytest -s -v -m "inference" skops/
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,9 +43,9 @@ jobs:
         fetch-depth: 0
         ref: ${{github.event.after}}
 
-    # - run: |
-    #     echo PR_COMMIT_MESSAGE=$(git log -1 --pretty=format:\"%s\") >> $GITHUB_ENV
-    #   shell: bash
+    - run: |
+        echo PR_COMMIT_MESSAGE=$(git log -1 --pretty=format:\"%s\") >> $GITHUB_ENV
+      shell: bash
 
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v3
@@ -82,8 +82,7 @@ jobs:
       run: mypy --config-file pyproject.toml skops
 
     - name: Inference tests (conditional)
-      # if: contains(env.PR_COMMIT_MESSAGE, '[CI inference]')
-      if: contains(github.event.head_commit.message, '[CI inference]')
+      if: contains(env.PR_COMMIT_MESSAGE, '[CI inference]')
       run: |
         python -m pytest -s -v -m "inference" skops/
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,12 @@ internet with:
 
 .. code:: bash
 
-   pytest -m "not network"
+   pytest -m "not network" skops
+
+Similarly, there is a flag, ``-m inference`` for tests that hit the Hugging Face
+Inference API, which can be quite slow or even hang. Skip these tests as long as
+you don't make any changes to this functionality. If you already skip network
+tests, the inference tests will also be skipped.
 
 
 Releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ filterwarnings = [
 ]
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",
+    "inference: marks tests that call inference API (deselect with '-m \"not inference\"')",
 ]
 addopts = "--cov=skops --cov-report=term-missing --doctest-modules"
 

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -395,6 +395,7 @@ def repo_path_for_inference():
 
 
 @pytest.mark.network
+@pytest.mark.inference
 @pytest.mark.skipif(
     IS_SKLEARN_DEV_BUILD, reason="Inference tests cannot run with sklearn dev build"
 )
@@ -414,7 +415,8 @@ def test_inference(
     repo_path_for_inference,
     destination_path,
 ):
-    # test inference backend for classifier and regressor models.
+    # test inference backend for classifier and regressor models. This test can
+    # take a lot of time and be flaky.
     client = HfApi()
 
     repo_path = repo_path_for_inference


### PR DESCRIPTION
Only if the commit message contains `"[CI inference]"` will those tests be run.

Second attempt after #147 failed, supersedes it, look there for more context.

- CI run without `"[CI inference]"` in commit message: https://github.com/skops-dev/skops/actions/runs/3436063562/jobs/5729156307
- CI run with `"[CI inference]"` in commit message: https://github.com/skops-dev/skops/actions/runs/3435994553/jobs/5729011327

Ready for review @skops-dev/maintainers 