### PR TITLE
MNT error in init if given file is empty

### DIFF
--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -8,7 +8,6 @@ import collections
 import json
 import os
 import shutil
-import warnings
 from pathlib import Path
 from typing import Any, List, MutableMapping, Optional, Union
 
@@ -235,7 +234,7 @@ def _check_model_file(path: str | Path) -> Path:
         raise OSError(f"Model file '{path}' does not exist.")
 
     if os.path.getsize(path) == 0:
-        warnings.warn(f"Model file '{path}' is empty.")
+        raise RuntimeError(f"Model file '{path}' is empty.")
 
     return Path(path)
 

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -307,17 +307,16 @@ def test_model_file_does_not_exist_raises(repo_path, config_json):
     path_unlink(model_path, missing_ok=True)
 
 
-def test_init_empty_model_file_warns(repo_path, config_json):
+def test_init_empty_model_file_errors(repo_path, config_json):
     # when model file is empty, warn users
-    model_path = repo_path / "foobar.pickle"
-    with open(model_path, "wb"):
-        pass
+    model_path = Path(repo_path / "foobar.pickle")
+    model_path.touch()
 
     dir_path = tempfile.mkdtemp()
     shutil.rmtree(dir_path)
     version = metadata.version("scikit-learn")
 
-    with pytest.warns() as rec:
+    with pytest.raises(RuntimeError, match=f"Model file '{model_path}' is empty."):
         init(
             model=model_path,
             requirements=[f'scikit-learn="{version}"'],
@@ -325,8 +324,6 @@ def test_init_empty_model_file_warns(repo_path, config_json):
             task="tabular-classification",
             data=iris.data,
         )
-        assert len(rec) == 1
-        assert rec[0].message.args[0] == f"Model file '{model_path}' is empty."
     path_unlink(model_path, missing_ok=True)
 
 


### PR DESCRIPTION
related to the error raised in https://github.com/skops-dev/skops/pull/207

This makes us raise if a given model file is empty.