### PR TITLE
DOC add a community page with link to discord

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,33 @@
+.. _community:
+
+Community
+---------
+Our community works mostly on `GitHub <https://github.com/skops-dev/skops/>`__,
+directly on issues and pull requests.
+
+If you encounter any issues, please don't hesitate to open an issue on our
+repository.
+
+If you'd like to contribute to the project, please make sure you read our
+`contributing guidelines
+<https://github.com/skops-dev/skops/blob/main/CONTRIBUTING.rst>`__.
+
+
+Discord
+~~~~~~~
+We also have a place on Hugging Face's discord server. We're happy to see you
+there and answer any questions you might have. You can join using this `invite
+link <http://hf.co/join/discord>`__. Once you join, first you need to accept
+the rules on the server regarding respectful and harassment free communication,
+and then you can head to the ``#role-assignment`` channel where you'll find and
+``Open Source ML`` button. Clicking on that will give you access to a few
+channels and categories, including the ``skops`` category.
+
+Maintainers
+-----------
+Current maintainers of the project are (in alphabetical order):
+
+- `Adrin Jalali <https://github.com/adrinjalali/>`__
+- `Benjamin Bossan <https://github.com/benjaminbossan>`__
+- `Erin Aho <https://github.com/E-Aho>`__
+- `Merve Noyan <https://github.com/merveenoyan>`__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,13 @@ User Guide / API Reference
    model_card
    persistence
    modules/classes
+
+Community / About
+=================
+.. toctree::
+   :maxdepth: 1
+
+   community
    changes
 
 Indices and tables


### PR DESCRIPTION
cc @skops-dev/maintainers 

I've put your GH pages here as links, but we can put whatever links you prefer.