### PR TITLE
CI: Update version of GH checkout action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     # message and make it available in later steps. This is because we want to
     # check the content of the commit message, but on PRs, it's replaced by an
     # artificial commit message. See https://github.com/skops-dev/skops/pull/147
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{github.event.after}}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     # message and make it available in later steps. This is because we want to
     # check the content of the commit message, but on PRs, it's replaced by an
     # artificial commit message. See https://github.com/skops-dev/skops/pull/147
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         ref: ${{github.event.after}}
@@ -48,7 +48,7 @@ jobs:
       shell: bash
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
Version 4 should get rid of the deprecation warning:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I guess that's the deprecation that what Adrin meant in #231:

> There's also a deprecation issue in the GH CI definition which needs to be fixed.

Here are all warnings from an older CI run:

https://github.com/skops-dev/skops/actions/runs/3592690842

Here they are from this PR:

https://github.com/skops-dev/skops/actions/runs/3593038193

So the deprecation is gone.

Ready for review @skops-dev/maintainers 