### PR TITLE
CI fix clean_skops.py

### DIFF
--- a/scripts/clean_skops.py
+++ b/scripts/clean_skops.py
@@ -10,19 +10,19 @@ from huggingface_hub import HfApi
 
 # This is the token for the skops user. TODO remove eventually, see issue #47
 token = "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"
-client = HfApi()
-user = client.whoami(token=token)["name"]
+client = HfApi(token=token)
+user = client.whoami()["name"]
 answer = input(
     f"Are you sure you want to delete all repos under {user} older than 7 days? (y/[n])"
 )
 if answer != "y":
     exit(1)
-models = client.list_models(author=user)
+models = [x for x in client.list_models(author=user)]
 
 print(f"Found {len(models)} models, checking their age...")
 
 for model_info in models:
-    info = client.model_info(model_info.modelId, token=token)
+    info = client.model_info(model_info.modelId)
     age = (
         datetime.datetime.now()
         - datetime.datetime.fromisoformat(info.lastModified.rsplit(".", 1)[0])
@@ -31,4 +31,4 @@ for model_info in models:
         print(f"Skipping model: {model_info.modelId}, age: {age}")
         continue
     print(f"deleting {model_info.modelId}, age: {age} days")
-    client.delete_repo(model_info.modelId, token=token)
+    client.delete_repo(model_info.modelId)


### PR DESCRIPTION
Fixes #231

This fixes the broken `clean_skops.py`.

- We can now pass the token to the client instance
- The output of `list_models` is a generator now
- Most models are private, so the token was required to list them, which were previously ignored

cc @skops-dev/maintainers 

The script works locally now.