### PR TITLE
CI update setup-python step to v4

### DIFF
--- a/.github/workflows/clean-skops-user.yml
+++ b/.github/workflows/clean-skops-user.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
     - name: Install Requirements
       run: pip install huggingface_hub
     - name: run cleanup

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         ref: ${{ github.event.inputs.version }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
This also removes the GH action deprecation warning:

```
 Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

cc @skops-dev/maintainers 