### PR TITLE
Add support for LightGBM and XGBoost

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -87,6 +87,24 @@ means if you have custom functions (say, a custom function to be used with
 most ``numpy`` and ``scipy`` functions should work. Therefore, you can actually
 save built-in functions like ``numpy.sqrt``.
 
+Supported libraries
+-------------------
+
+Skops intends to support all of **scikit-learn**, that is, not only its
+estimators, but also other classes like cross validation splitters. Furthermore,
+most types from **numpy** and **scipy** should be supported, such as (sparse)
+arrays, dtypes, random generators, and ufuncs.
+
+Apart from this core, we plan to support machine learning libraries commonly
+used be the community. So far, those are:
+
+- `LightGBM <lightgbm.readthedocs.io/>`_ (scikit-learn API)
+
+If you run into a problem using any of the mentioned libraries, this could mean
+there is a bug in skops. Please open an issue on `our issue tracker
+<https://github.com/skops-dev/skops/issues>`_ (but please check first if a
+corresponding issue already exists).
+
 Roadmap
 -------
 

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -27,6 +27,9 @@ dependent_packages = {
     "matplotlib": ("3.3", "docs, tests", None),
     "pandas": ("1", "docs, tests", None),
     "typing_extensions": ("3.7", "install", "python_full_version < '3.8'"),
+    # required for persistence tests of external libraries
+    "lightgbm": ("3", "tests", None),
+    "xgboost": ("1.7", "tests", None),
 }
 
 

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -14,7 +14,7 @@ from ._utils import LoadContext, SaveContext, _get_state, get_state
 
 # We load the dispatch functions from the corresponding modules and register
 # them.
-modules = ["._general", "._numpy", "._scipy", "._sklearn"]
+modules = ["._general", "._numpy", "._scipy", "._sklearn", "._xgboost"]
 for module_name in modules:
     # register exposed functions for get_state and get_tree
     module = importlib.import_module(module_name, package="skops.io")

--- a/skops/io/_xgboost.py
+++ b/skops/io/_xgboost.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import io
+import tempfile
+from typing import Any, Sequence
+from uuid import uuid4
+
+import sklearn.exceptions
+
+from ._audit import Node, get_tree
+from ._utils import LoadContext, SaveContext, get_module, get_state
+
+try:
+    import xgboost
+except ImportError:
+    xgboost = None  # type: ignore
+
+
+def xgboost_get_state(obj: Any, save_context: SaveContext) -> dict[str, Any]:
+    res = {
+        "__class__": obj.__class__.__name__,
+        "__module__": get_module(type(obj)),
+        "__loader__": "XGBoostNode",
+        "constructor": type(obj).__name__,
+    }
+
+    # fitted vs not fitted models require different approaches
+    try:
+        # xgboost doesn't allow to save to a memory buffer, so take roundtrip
+        # through temp file
+        tmp_file = f"{tempfile.mkdtemp()}.ubj"
+        obj.save_model(tmp_file)
+        with open(tmp_file, "rb") as f:
+            data_buffer = io.BytesIO(f.read())
+        f_name = f"xgboost_{uuid4()}.json"
+        save_context.zip_file.writestr(f_name, data_buffer.getbuffer())
+        res.update(type="xgboost-format", file=f_name)
+    except sklearn.exceptions.NotFittedError:
+        res.update(type="params", content=get_state(obj.get_params(), save_context))
+
+    return res
+
+
+class XGBoostNode(Node):
+    def __init__(
+        self,
+        state: dict[str, Any],
+        load_context: LoadContext,
+        trusted: bool | Sequence[str] = False,
+    ) -> None:
+        super().__init__(state, load_context, trusted)
+        self.type = state["type"]
+        self.trusted = self._get_trusted(trusted, [])
+
+        # list of constructors is hard-coded for higher security
+        constructors = {
+            "XGBClassifier": xgboost.XGBClassifier,
+            "XGBRegressor": xgboost.XGBRegressor,
+            "XGBRFClassifier": xgboost.XGBRFClassifier,
+            "XGBRFRegressor": xgboost.XGBRFRegressor,
+            "XGBRanker": xgboost.XGBRanker,
+        }
+        self.children = {"constructor": constructors[state["constructor"]]}
+        if self.type == "xgboost-format":  # fitted xgboost model
+            self.children["content"] = io.BytesIO(load_context.src.read(state["file"]))
+        else:
+            self.children["content"] = get_tree(state["content"], load_context)
+
+    def _construct(self):
+        cls = self.children["constructor"]
+        instance = cls()
+
+        if self.type == "xgboost-format":  # fitted
+            # load_model works with bytearray, so no temp file necessary here
+            instance.load_model(bytearray(self.children["content"].getvalue()))
+        else:
+            params = self.children["content"].construct()
+            instance.set_params(**params)
+
+        return instance
+
+
+GET_STATE_DISPATCH_FUNCTIONS = []  # type: ignore
+NODE_TYPE_MAPPING = {}
+
+if xgboost is not None:
+    GET_STATE_DISPATCH_FUNCTIONS.append((xgboost.sklearn.XGBModel, xgboost_get_state))
+    NODE_TYPE_MAPPING["XGBoostNode"] = XGBoostNode

--- a/skops/io/tests/_utils.py
+++ b/skops/io/tests/_utils.py
@@ -1,0 +1,145 @@
+import warnings
+
+import numpy as np
+from scipy import sparse
+from sklearn.base import BaseEstimator
+
+
+def _is_steps_like(obj):
+    # helper function to check if an object is something like Pipeline.steps,
+    # i.e. a list of tuples of names and estimators
+    if not isinstance(obj, list):  # must be a list
+        return False
+
+    if not obj:  # must not be empty
+        return False
+
+    if not isinstance(obj[0], tuple):  # must be list of tuples
+        return False
+
+    lens = set(map(len, obj))
+    if not lens == {2}:  # all elements must be length 2 tuples
+        return False
+
+    keys, vals = list(zip(*obj))
+
+    if len(keys) != len(set(keys)):  # keys must be unique
+        return False
+
+    if not all(map(lambda x: isinstance(x, (type(None), BaseEstimator)), vals)):
+        # values must be BaseEstimators or None
+        return False
+
+    return True
+
+
+def _assert_generic_objects_equal(val1, val2):
+    def _is_builtin(val):
+        # Check if value is a builtin type
+        return getattr(getattr(val, "__class__", {}), "__module__", None) == "builtins"
+
+    if isinstance(val1, (list, tuple, np.ndarray)):
+        assert len(val1) == len(val2)
+        for subval1, subval2 in zip(val1, val2):
+            _assert_generic_objects_equal(subval1, subval2)
+            return
+
+    assert type(val1) == type(val2)
+    if hasattr(val1, "__dict__"):
+        assert_params_equal(val1.__dict__, val2.__dict__)
+    elif _is_builtin(val1):
+        assert val1 == val2
+    else:
+        # not a normal Python class, could be e.g. a Cython class
+        assert val1.__reduce__() == val2.__reduce__()
+
+
+def _assert_tuples_equal(val1, val2):
+    assert len(val1) == len(val2)
+    for subval1, subval2 in zip(val1, val2):
+        _assert_vals_equal(subval1, subval2)
+
+
+def _assert_vals_equal(val1, val2):
+    if hasattr(val1, "__getstate__"):
+        # This includes BaseEstimator since they implement __getstate__ and
+        # that returns the parameters as well.
+        #
+        # Some objects return a tuple of parameters, others a dict.
+        state1 = val1.__getstate__()
+        state2 = val2.__getstate__()
+        assert type(state1) == type(state2)
+        if isinstance(state1, tuple):
+            _assert_tuples_equal(state1, state2)
+        else:
+            assert_params_equal(val1.__getstate__(), val2.__getstate__())
+    elif sparse.issparse(val1):
+        assert sparse.issparse(val2) and ((val1 - val2).nnz == 0)
+    elif isinstance(val1, (np.ndarray, np.generic)):
+        if len(val1.dtype) == 0:
+            # for arrays with at least 2 dimensions, check that contiguity is
+            # preserved
+            if val1.squeeze().ndim > 1:
+                assert val1.flags["C_CONTIGUOUS"] is val2.flags["C_CONTIGUOUS"]
+                assert val1.flags["F_CONTIGUOUS"] is val2.flags["F_CONTIGUOUS"]
+            if val1.dtype == object:
+                assert val2.dtype == object
+                assert val1.shape == val2.shape
+                for subval1, subval2 in zip(val1, val2):
+                    _assert_generic_objects_equal(subval1, subval2)
+            else:
+                # simple comparison of arrays with simple dtypes, almost all
+                # arrays are of this sort.
+                np.testing.assert_array_equal(val1, val2)
+        elif len(val1.shape) == 1:
+            # comparing arrays with structured dtypes, but they have to be 1D
+            # arrays. This is what we get from the Tree's state.
+            assert np.all([x == y for x, y in zip(val1, val2)])
+        else:
+            # we don't know what to do with these values, for now.
+            assert False
+    elif isinstance(val1, (tuple, list)):
+        assert len(val1) == len(val2)
+        for subval1, subval2 in zip(val1, val2):
+            _assert_vals_equal(subval1, subval2)
+    elif isinstance(val1, float) and np.isnan(val1):
+        assert np.isnan(val2)
+    elif isinstance(val1, dict):
+        # dictionaries are compared by comparing their values recursively.
+        assert set(val1.keys()) == set(val2.keys())
+        for key in val1:
+            _assert_vals_equal(val1[key], val2[key])
+    elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
+        _assert_vals_equal(val1.__dict__, val2.__dict__)
+    elif isinstance(val1, np.ufunc):
+        assert val1 == val2
+    elif val1.__class__.__module__ == "builtins":
+        assert val1 == val2
+    else:
+        _assert_generic_objects_equal(val1, val2)
+
+
+def assert_params_equal(params1, params2):
+    # helper function to compare estimator dictionaries of parameters
+    assert len(params1) == len(params2)
+    assert set(params1.keys()) == set(params2.keys())
+    for key in params1:
+        with warnings.catch_warnings():
+            # this is to silence the deprecation warning from _DictWithDeprecatedKeys
+            warnings.filterwarnings("ignore", category=FutureWarning, module="sklearn")
+            val1, val2 = params1[key], params2[key]
+        assert type(val1) == type(val2)
+
+        if _is_steps_like(val1):
+            # Deal with Pipeline.steps, FeatureUnion.transformer_list, etc.
+            assert _is_steps_like(val2)
+            val1, val2 = dict(val1), dict(val2)
+
+        if isinstance(val1, (tuple, list)):
+            assert len(val1) == len(val2)
+            for subval1, subval2 in zip(val1, val2):
+                _assert_vals_equal(subval1, subval2)
+        elif isinstance(val1, dict):
+            assert_params_equal(val1, val2)
+        else:
+            _assert_vals_equal(val1, val2)

--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -1,0 +1,296 @@
+import sys
+
+import pytest
+from sklearn.datasets import make_classification, make_regression
+from sklearn.utils._testing import assert_allclose_dense_sparse
+
+from skops.io import dumps, loads
+from skops.io.tests._utils import assert_params_equal
+
+ATOL = 1e-6 if sys.platform == "darwin" else 1e-7
+# Default settings for generated data
+N_SAMPLES = 30
+N_FEATURES = 10
+N_CLASSES = 4  # for classification only
+
+
+@pytest.fixture(scope="module")
+def clf_data():
+    X, y = make_classification(
+        n_samples=N_SAMPLES,
+        n_classes=N_CLASSES,
+        n_features=N_FEATURES,
+        random_state=0,
+        n_redundant=1,
+        n_informative=N_FEATURES - 1,
+    )
+    return X, y
+
+
+@pytest.fixture(scope="module")
+def regr_data():
+    X, y = make_regression(n_samples=N_SAMPLES, n_features=N_FEATURES, random_state=0)
+    return X, y
+
+
+@pytest.fixture(scope="module")
+def rank_data(clf_data):
+    X, y = clf_data
+    group = [10 for _ in range(N_SAMPLES // 10)]
+    n = sum(group)
+    if N_SAMPLES > n:
+        group[-1] += N_SAMPLES - n
+    assert sum(group) == N_SAMPLES
+    return X, y, group
+
+
+def check_estimator(estimator, trusted):
+    loaded = loads(dumps(estimator), trusted=trusted)
+    assert_params_equal(estimator.get_params(), loaded.get_params())
+
+
+def check_method_outputs(estimator, X, trusted):
+    loaded = loads(dumps(estimator), trusted=trusted)
+    for method in [
+        "predict",
+        "predict_proba",
+        "decision_function",
+        "transform",
+        "predict_log_proba",
+    ]:
+        err_msg = (
+            f"{estimator.__class__.__name__}.{method}() doesn't produce the same"
+            " results after loading the persisted model."
+        )
+        if hasattr(estimator, method):
+            X_out1 = getattr(estimator, method)(X)
+            X_out2 = getattr(loaded, method)(X)
+            assert_allclose_dense_sparse(X_out1, X_out2, err_msg=err_msg, atol=ATOL)
+
+
+class TestLightGBM:
+    """Tests for LGBMClassifier, LGBMRegressor, LGBMRanker"""
+
+    @pytest.fixture(autouse=True)
+    def lgbm(self):
+        lgbm = pytest.importorskip("lightgbm")
+        return lgbm
+
+    @pytest.fixture
+    def trusted(self):
+        return [
+            "collections.defaultdict",
+            "lightgbm.basic.Booster",
+            "lightgbm.sklearn.LGBMClassifier",
+            "lightgbm.sklearn.LGBMRegressor",
+            "lightgbm.sklearn.LGBMRanker",
+            "numpy.int64",
+            "sklearn.preprocessing._label.LabelEncoder",
+        ]
+
+    boosting_types = ["gbdt", "dart", "goss", "rf"]
+
+    @pytest.mark.parametrize("boosting_type", boosting_types)
+    def test_classifier(self, lgbm, clf_data, trusted, boosting_type):
+        kw = {}
+        if boosting_type == "rf":
+            kw["bagging_fraction"] = 0.5
+            kw["bagging_freq"] = 2
+
+        estimator = lgbm.LGBMClassifier(boosting_type=boosting_type, **kw)
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = clf_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("boosting_type", boosting_types)
+    def test_regressor(self, lgbm, regr_data, trusted, boosting_type):
+        kw = {}
+        if boosting_type == "rf":
+            kw["bagging_fraction"] = 0.5
+            kw["bagging_freq"] = 2
+
+        estimator = lgbm.LGBMRegressor(boosting_type=boosting_type, **kw)
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = regr_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("boosting_type", boosting_types)
+    def test_ranker(self, lgbm, rank_data, trusted, boosting_type):
+        kw = {}
+        if boosting_type == "rf":
+            kw["bagging_fraction"] = 0.5
+            kw["bagging_freq"] = 2
+
+        estimator = lgbm.LGBMRanker(boosting_type=boosting_type, **kw)
+        check_estimator(estimator, trusted=trusted)
+
+        X, y, group = rank_data
+        estimator.fit(X, y, group=group)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+
+class TestXGBoost:
+    """Tests for XGBClassifier, XGBRegressor, XGBRFClassifier, XGBRFRegressor, XGBRanker
+
+    Known bugs:
+
+    - When initialzing with tree_method=None, its value resolves to "exact", but
+      after loading, it resolves to "auto".
+    - When initializing with gpu_id=None, its value resolves to 0, but after
+      loading, it resolves to -1.
+
+    This can be verified like this:
+
+    >>> import xgboost
+    >>> estimator = xgboost.XGBClassifier(tree_method=None)
+    >>> X, y = [[0, 1], [2, 3]], [0, 1]
+    >>> estimator.fit(X, y)
+    XGBClassifier(...)
+    >>> print(estimator.tree_method)
+    None
+    >>> print(estimator.get_params()["tree_method"])
+    exact
+    >>> # after save/load roundtrip, values of get_params change
+    >>> import tempfile
+    >>> tmp_file = f"{tempfile.mkdtemp()}.ubj"
+    >>> estimator.save_model(tmp_file)
+    >>> estimator.load_model(tmp_file)
+    >>> print(estimator.tree_method)
+    None
+    >>> print(estimator.get_params()["tree_method"])
+    auto
+
+    >>> estimator = xgboost.XGBClassifier(tree_method='gpu_hist', booster='gbtree')
+    >>> estimator.fit(X, y)
+    XGBClassifier(...)
+    >>> print(estimator.gpu_id)
+    None
+    >>> print(estimator.get_params()["gpu_id"])
+    0
+    >>> # after save/load roundtrip, values of get_params change
+    >>> estimator.save_model(tmp_file)
+    >>> # for gpu_id, the estimator needs to be re-initialized for the effect to occur
+    >>> estimator = xgboost.XGBClassifier()
+    >>> estimator.load_model(tmp_file)
+    >>> print(estimator.gpu_id)
+    None
+    >>> print(estimator.get_params()["gpu_id"])
+    -1
+
+    As can be seen, this has nothing to do with skops but is a bug/feature of
+    xgboost. We assume that this has no practical consequences and thus avoid
+    testing these cases.
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def xgboost(self):
+        xgboost = pytest.importorskip("xgboost")
+        return xgboost
+
+    @pytest.fixture
+    def trusted(self):
+        return [
+            "xgboost.sklearn.XGBClassifier",
+            "xgboost.sklearn.XGBRegressor",
+            "xgboost.sklearn.XGBRFClassifier",
+            "xgboost.sklearn.XGBRFRegressor",
+            "xgboost.sklearn.XGBRanker",
+            "builtins.bytearray",
+            "xgboost.core.Booster",
+        ]
+
+    boosters = ["gbtree", "gblinear", "dart"]
+    tree_methods = ["approx", "hist", "gpu_hist", "auto"]
+
+    @pytest.mark.parametrize("booster", boosters)
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_classifier(self, xgboost, clf_data, trusted, booster, tree_method):
+        if (booster == "gblinear") and (tree_method != "approx"):
+            # This parameter combination is not supported in XGBoost
+            return
+
+        estimator = xgboost.XGBClassifier(
+            booster=booster, tree_method=tree_method, gpu_id=-1
+        )
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = clf_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("booster", boosters)
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_regressor(self, xgboost, regr_data, trusted, booster, tree_method):
+        if (booster == "gblinear") and (tree_method != "approx"):
+            # This parameter combination is not supported in XGBoost
+            return
+
+        estimator = xgboost.XGBRegressor(
+            booster=booster, tree_method=tree_method, gpu_id=-1
+        )
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = regr_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("booster", boosters)
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_rf_classifier(self, xgboost, clf_data, trusted, booster, tree_method):
+        if (booster == "gblinear") and (tree_method != "approx"):
+            # This parameter combination is not supported in XGBoost
+            return
+
+        estimator = xgboost.XGBRFClassifier(
+            booster=booster, tree_method=tree_method, gpu_id=-1
+        )
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = clf_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("booster", boosters)
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_rf_regressor(self, xgboost, regr_data, trusted, booster, tree_method):
+        if (booster == "gblinear") and (tree_method != "approx"):
+            # This parameter combination is not supported in XGBoost
+            return
+
+        estimator = xgboost.XGBRFRegressor(
+            booster=booster, tree_method=tree_method, gpu_id=-1
+        )
+        check_estimator(estimator, trusted=trusted)
+
+        X, y = regr_data
+        estimator.fit(X, y)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)
+
+    @pytest.mark.parametrize("booster", boosters)
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_ranker(self, xgboost, rank_data, trusted, booster, tree_method):
+        if (booster == "gblinear") and (tree_method != "approx"):
+            # This parameter combination is not supported in XGBoost
+            return
+
+        estimator = xgboost.XGBRanker(
+            booster=booster, tree_method=tree_method, gpu_id=-1
+        )
+        check_estimator(estimator, trusted=trusted)
+
+        X, y, group = rank_data
+        estimator.fit(X, y, group=group)
+        check_estimator(estimator, trusted=trusted)
+        check_method_outputs(estimator, X, trusted=trusted)

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -58,6 +58,7 @@ from skops.io._audit import NODE_TYPE_MAPPING, get_tree
 from skops.io._sklearn import UNSUPPORTED_TYPES
 from skops.io._utils import LoadContext, SaveContext, _get_state, get_state
 from skops.io.exceptions import UnsupportedTypeException
+from skops.io.tests._utils import assert_params_equal
 
 # Default settings for X
 N_SAMPLES = 50
@@ -112,7 +113,7 @@ def debug_dispatch_functions():
 
         return wrapper
 
-    modules = ["._general", "._numpy", "._scipy", "._sklearn"]
+    modules = ["._general", "._numpy", "._scipy", "._sklearn", "._xgboost"]
     for module_name in modules:
         # overwrite exposed functions for get_state and get_tree
         module = importlib.import_module(module_name, package="skops.io")
@@ -255,146 +256,6 @@ def _unsupported_estimators(type_filter=None):
             continue
 
         yield estimator
-
-
-def _is_steps_like(obj):
-    # helper function to check if an object is something like Pipeline.steps,
-    # i.e. a list of tuples of names and estimators
-    if not isinstance(obj, list):  # must be a list
-        return False
-
-    if not obj:  # must not be empty
-        return False
-
-    if not isinstance(obj[0], tuple):  # must be list of tuples
-        return False
-
-    lens = set(map(len, obj))
-    if not lens == {2}:  # all elements must be length 2 tuples
-        return False
-
-    keys, vals = list(zip(*obj))
-
-    if len(keys) != len(set(keys)):  # keys must be unique
-        return False
-
-    if not all(map(lambda x: isinstance(x, (type(None), BaseEstimator)), vals)):
-        # values must be BaseEstimators or None
-        return False
-
-    return True
-
-
-def _assert_generic_objects_equal(val1, val2):
-    def _is_builtin(val):
-        # Check if value is a builtin type
-        return getattr(getattr(val, "__class__", {}), "__module__", None) == "builtins"
-
-    if isinstance(val1, (list, tuple, np.ndarray)):
-        assert len(val1) == len(val2)
-        for subval1, subval2 in zip(val1, val2):
-            _assert_generic_objects_equal(subval1, subval2)
-            return
-
-    assert type(val1) == type(val2)
-    if hasattr(val1, "__dict__"):
-        assert_params_equal(val1.__dict__, val2.__dict__)
-    elif _is_builtin(val1):
-        assert val1 == val2
-    else:
-        # not a normal Python class, could be e.g. a Cython class
-        assert val1.__reduce__() == val2.__reduce__()
-
-
-def _assert_tuples_equal(val1, val2):
-    assert len(val1) == len(val2)
-    for subval1, subval2 in zip(val1, val2):
-        _assert_vals_equal(subval1, subval2)
-
-
-def _assert_vals_equal(val1, val2):
-    if hasattr(val1, "__getstate__"):
-        # This includes BaseEstimator since they implement __getstate__ and
-        # that returns the parameters as well.
-        #
-        # Some objects return a tuple of parameters, others a dict.
-        state1 = val1.__getstate__()
-        state2 = val2.__getstate__()
-        assert type(state1) == type(state2)
-        if isinstance(state1, tuple):
-            _assert_tuples_equal(state1, state2)
-        else:
-            assert_params_equal(val1.__getstate__(), val2.__getstate__())
-    elif sparse.issparse(val1):
-        assert sparse.issparse(val2) and ((val1 - val2).nnz == 0)
-    elif isinstance(val1, (np.ndarray, np.generic)):
-        if len(val1.dtype) == 0:
-            # for arrays with at least 2 dimensions, check that contiguity is
-            # preserved
-            if val1.squeeze().ndim > 1:
-                assert val1.flags["C_CONTIGUOUS"] is val2.flags["C_CONTIGUOUS"]
-                assert val1.flags["F_CONTIGUOUS"] is val2.flags["F_CONTIGUOUS"]
-            if val1.dtype == object:
-                assert val2.dtype == object
-                assert val1.shape == val2.shape
-                for subval1, subval2 in zip(val1, val2):
-                    _assert_generic_objects_equal(subval1, subval2)
-            else:
-                # simple comparison of arrays with simple dtypes, almost all
-                # arrays are of this sort.
-                np.testing.assert_array_equal(val1, val2)
-        elif len(val1.shape) == 1:
-            # comparing arrays with structured dtypes, but they have to be 1D
-            # arrays. This is what we get from the Tree's state.
-            assert np.all([x == y for x, y in zip(val1, val2)])
-        else:
-            # we don't know what to do with these values, for now.
-            assert False
-    elif isinstance(val1, (tuple, list)):
-        assert len(val1) == len(val2)
-        for subval1, subval2 in zip(val1, val2):
-            _assert_vals_equal(subval1, subval2)
-    elif isinstance(val1, float) and np.isnan(val1):
-        assert np.isnan(val2)
-    elif isinstance(val1, dict):
-        # dictionaries are compared by comparing their values recursively.
-        assert set(val1.keys()) == set(val2.keys())
-        for key in val1:
-            _assert_vals_equal(val1[key], val2[key])
-    elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
-        _assert_vals_equal(val1.__dict__, val2.__dict__)
-    elif isinstance(val1, np.ufunc):
-        assert val1 == val2
-    elif val1.__class__.__module__ == "builtins":
-        assert val1 == val2
-    else:
-        _assert_generic_objects_equal(val1, val2)
-
-
-def assert_params_equal(params1, params2):
-    # helper function to compare estimator dictionaries of parameters
-    assert len(params1) == len(params2)
-    assert set(params1.keys()) == set(params2.keys())
-    for key in params1:
-        with warnings.catch_warnings():
-            # this is to silence the deprecation warning from _DictWithDeprecatedKeys
-            warnings.filterwarnings("ignore", category=FutureWarning, module="sklearn")
-            val1, val2 = params1[key], params2[key]
-        assert type(val1) == type(val2)
-
-        if _is_steps_like(val1):
-            # Deal with Pipeline.steps, FeatureUnion.transformer_list, etc.
-            assert _is_steps_like(val2)
-            val1, val2 = dict(val1), dict(val2)
-
-        if isinstance(val1, (tuple, list)):
-            assert len(val1) == len(val2)
-            for subval1, subval2 in zip(val1, val2):
-                _assert_vals_equal(subval1, subval2)
-        elif isinstance(val1, dict):
-            assert_params_equal(val1, val2)
-        else:
-            _assert_vals_equal(val1, val2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Partially solves #226

## Description

LightGBM already worked out of the box, so for this, only tests were added. For XGBoost, extra code was added to support it.

## Implementation

Dependencies were extended to include xgboost and lightgbm for testing, so that they should be covered by CI. If those libraries are not installed, the tests should be gracefully skipped.

For xgboost, the xgboost-specific persistence format was chosen, which can be used through `estimator.save_model` and `estimator.load_model`. I could not verify (yet) that this format is 100% secure. However, since it's a binary json file (`.ubj`), it should as secure as json. More information here:

https://xgboost.readthedocs.io/en/stable/tutorials/saving_model.html

The actual implementation for xgboost mirrors the one for numpy arrays, which also stores its data in an external file. However, I did not apply any caching here, as it seems it wouldn't be useful.

I decided to create a new test file, `test_external.py`, to put the new tests, instead of cramming more into `test_persist.py`. Since some functions from `test_persist.py` were required here, I moved them a new `_utils.py` module.

Interestingly, I found some potential bugs where some values returned by `get_params()` may differ for xgboost models after loading. This is independent of skops. Those edge cases are documented but were excluded from tests, as it appears that they should be inconsequential. We may want to report them.