### PR TITLE
MNT: Change placeholder character to control character

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -41,7 +41,7 @@ def _clean_table(table: str) -> str:
     # replace line breaks "\n" with html tag <br />, however, leave end-of-line
     # line breaks (eol_lb) intact
     eol_lb = "|\n"
-    placeholder = "$%!?"  # arbitrary string that never appears naturally
+    placeholder = "\x1f"  # unit separator control character
     table = (
         table.replace(eol_lb, placeholder)
         .replace("\n", "<br />")
@@ -195,7 +195,7 @@ def split_subsection_names(key: str) -> list[str]:
         The individual (sub)sections.
 
     """
-    placeholder = "$%!?"  # arbitrary sting that never appears naturally
+    placeholder = "\x1f"  # unit separator control character
     key = key.replace("\\/", placeholder)
     parts = (part.strip() for part in key.split("/"))
     return [part.replace(placeholder, "/") for part in parts]

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -5,6 +5,7 @@ import re
 import textwrap
 import zipfile
 from collections.abc import Mapping
+from curses import ascii
 from dataclasses import dataclass, field
 from pathlib import Path
 from reprlib import Repr
@@ -41,7 +42,7 @@ def _clean_table(table: str) -> str:
     # replace line breaks "\n" with html tag <br />, however, leave end-of-line
     # line breaks (eol_lb) intact
     eol_lb = "|\n"
-    placeholder = "\x1f"  # unit separator control character
+    placeholder = chr(ascii.US)  # unit separator control character, \x1f
     table = (
         table.replace(eol_lb, placeholder)
         .replace("\n", "<br />")
@@ -195,7 +196,7 @@ def split_subsection_names(key: str) -> list[str]:
         The individual (sub)sections.
 
     """
-    placeholder = "\x1f"  # unit separator control character
+    placeholder = chr(ascii.US)  # unit separator control character, \x1f
     key = key.replace("\\/", placeholder)
     parts = (part.strip() for part in key.split("/"))
     return [part.replace(placeholder, "/") for part in parts]

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -41,7 +41,7 @@ def _clean_table(table: str) -> str:
     # replace line breaks "\n" with html tag <br />, however, leave end-of-line
     # line breaks (eol_lb) intact
     eol_lb = "|\n"
-    placeholder = "\x1f"  # unit separator control character
+    placeholder = "\x1f"  # unit separator control character (ASCII control char 31)
     table = (
         table.replace(eol_lb, placeholder)
         .replace("\n", "<br />")
@@ -195,7 +195,7 @@ def split_subsection_names(key: str) -> list[str]:
         The individual (sub)sections.
 
     """
-    placeholder = "\x1f"  # unit separator control character
+    placeholder = "\x1f"  # unit separator control character (ASCII control char 31)
     key = key.replace("\\/", placeholder)
     parts = (part.strip() for part in key.split("/"))
     return [part.replace(placeholder, "/") for part in parts]

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -5,7 +5,6 @@ import re
 import textwrap
 import zipfile
 from collections.abc import Mapping
-from curses import ascii
 from dataclasses import dataclass, field
 from pathlib import Path
 from reprlib import Repr
@@ -42,7 +41,7 @@ def _clean_table(table: str) -> str:
     # replace line breaks "\n" with html tag <br />, however, leave end-of-line
     # line breaks (eol_lb) intact
     eol_lb = "|\n"
-    placeholder = chr(ascii.US)  # unit separator control character, \x1f
+    placeholder = "\x1f"  # unit separator control character
     table = (
         table.replace(eol_lb, placeholder)
         .replace("\n", "<br />")
@@ -196,7 +195,7 @@ def split_subsection_names(key: str) -> list[str]:
         The individual (sub)sections.
 
     """
-    placeholder = chr(ascii.US)  # unit separator control character, \x1f
+    placeholder = "\x1f"  # unit separator control character
     key = key.replace("\\/", placeholder)
     parts = (part.strip() for part in key.split("/"))
     return [part.replace(placeholder, "/") for part in parts]


### PR DESCRIPTION
Small change that swaps from using an arbitrary string of real world characters to a unicode control character.

This should reduce the risk of bugs (e.g, the original code would cause bugs if a user decided to use '$%!?' in their model card subsection or table), and the `unit seperator` feels a good fit for this use case.