### PR TITLE
DOC make the persistence warning the same as the user guide

### DIFF
--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -48,10 +48,9 @@ def dump(obj: Any, file: str | Path | BinaryIO) -> None:
 
     .. warning::
 
-       This feature is very early in development, which means the API is
-       unstable and it is **not secure** at the moment. Therefore, use the same
-       caution as you would for ``pickle``: Don't load from sources that you
-       don't trust. In the future, more security will be added.
+        This feature is heavily under development, which means the API is
+        unstable and there might be security issues at the moment. Therefore,
+        use caution when loading files from sources you don't trust.
 
     Parameters
     ----------
@@ -78,10 +77,9 @@ def dumps(obj: Any) -> bytes:
 
     .. warning::
 
-       This feature is very early in development, which means the API is
-       unstable and it is **not secure** at the moment. Therefore, use the same
-       caution as you would for ``pickle``: Don't load from sources that you
-       don't trust. In the future, more security will be added.
+        This feature is heavily under development, which means the API is
+        unstable and there might be security issues at the moment. Therefore,
+        use caution when loading files from sources you don't trust.
 
     Parameters
     ----------
@@ -102,10 +100,9 @@ def load(file: str | Path, trusted: bool | Sequence[str] = False) -> Any:
 
     .. warning::
 
-       This feature is very early in development, which means the API is
-       unstable and it is **not secure** at the moment. Therefore, use the same
-       caution as you would for ``pickle``: Don't load from sources that you
-       don't trust. In the future, more security will be added.
+        This feature is heavily under development, which means the API is
+        unstable and there might be security issues at the moment. Therefore,
+        use caution when loading files from sources you don't trust.
 
     Parameters
     ----------
@@ -141,10 +138,9 @@ def loads(data: bytes, trusted: bool | Sequence[str] = False) -> Any:
 
     .. warning::
 
-       This feature is very early in development, which means the API is
-       unstable and it is **not secure** at the moment. Therefore, use the same
-       caution as you would for ``pickle``: Don't load from sources that you
-       don't trust. In the future, more security will be added.
+        This feature is heavily under development, which means the API is
+        unstable and there might be security issues at the moment. Therefore,
+        use caution when loading files from sources you don't trust.
 
     Parameters
     ----------


### PR DESCRIPTION
This is a hotfix to make the warning in the API docs the same as the user guide.

Since https://github.com/scikit-learn/scikit-learn/pull/25197 this merged and might be backported to the stable release soon, we should fix this warning, and backport it to the 0.4.X branch. It won't require a new release since it's only a documentation change.

I'll merge tomorrow if nobody else does. I don't like urgent things, but this might hurt us if we don't fix it soon.

cc @skops-dev/maintainers 