### PR TITLE
FIX: Persistence tests failing when using sklearn nightly

### DIFF
--- a/skops/io/tests/_utils.py
+++ b/skops/io/tests/_utils.py
@@ -126,6 +126,13 @@ def _assert_vals_equal(val1, val2):
 
 
 def assert_params_equal(params1, params2):
+    # due to https://github.com/scikit-learn/scikit-learn/pull/22094, after
+    # loading an sklearn estimator, there might be an entry called
+    # "__sklearn_pickle_version__" in the __dict__ that wasn't there before. We
+    # just ignore it.
+    params1.pop("__sklearn_pickle_version__", None)
+    params2.pop("__sklearn_pickle_version__", None)
+
     # helper function to compare estimator dictionaries of parameters
     assert len(params1) == len(params2)
     assert set(params1.keys()) == set(params2.keys())


### PR DESCRIPTION
This PR is urgent because CI for our PRs will fail until there is a fix.

After https://github.com/scikit-learn/scikit-learn/pull/22094, sklearn estimators will contain an additional key in their `__dict__` after loading, namely `"__sklearn_pickle_version__"`. This causes our tests to fail, since they compare objects before and after loading.

The quick solution is to pop the item in our tests if it exists and only compare the remaining items.

Should the sklearn change be amended, we should remove the fix from this PR. Progress is tracked here:

https://github.com/scikit-learn/scikit-learn/issues/25273