### PR TITLE
Turn off CatBoost verbosity in tests

### DIFF
--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -282,7 +282,9 @@ class TestCatboost:
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_classifier(self, catboost, cb_clf_data, trusted, boosting_type):
-        estimator = catboost.CatBoostClassifier(boosting_type=boosting_type)
+        estimator = catboost.CatBoostClassifier(
+            verbose=False, boosting_type=boosting_type
+        )
         loaded = loads(dumps(estimator), trusted=trusted)
         assert_params_equal(estimator.get_params(), loaded.get_params())
 
@@ -293,7 +295,9 @@ class TestCatboost:
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, catboost, cb_regr_data, trusted, boosting_type):
-        estimator = catboost.CatBoostRegressor(boosting_type=boosting_type)
+        estimator = catboost.CatBoostRegressor(
+            verbose=False, boosting_type=boosting_type
+        )
         loaded = loads(dumps(estimator), trusted=trusted)
         assert_params_equal(estimator.get_params(), loaded.get_params())
 
@@ -304,7 +308,7 @@ class TestCatboost:
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, catboost, cb_rank_data, trusted, boosting_type):
-        estimator = catboost.CatBoostRanker(boosting_type=boosting_type)
+        estimator = catboost.CatBoostRanker(verbose=False, boosting_type=boosting_type)
         loaded = loads(dumps(estimator), trusted=trusted)
         assert_params_equal(estimator.get_params(), loaded.get_params())
 


### PR DESCRIPTION
By default, catboost prints a giant output to stdout when fitting. This is annoying when running the tests, which include fitting catboost. Normally, this does not matter, as pytest captures stdout, but when running pytest with `-s` (e.g. for debugging purposes or in CI), the output is flooded.

This PR adds `verbose=False` when initializing the catboost estimators, which prevents any output from being shown.