### PR TITLE
ENH Work on supporting scikit-learn intelex

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,10 @@ v0.5
 ----
 - Support more array-like data types for tabular data and list-like data types
   for text data. :pr:`179` by `Francesco Cariaggi`_.
+- Add an option `use_intelex` to :func:`skops.hub_utils.init` which, when
+  enabled, will result in the Hugging Face inference API running with Intel's
+  scikit-learn intelex library, which can accelerate inference times. :pr:`267`
+  by `Benjamin Bossan`_.
 
 v0.4
 ----
@@ -31,10 +35,6 @@ v0.4
   section/New section": "content"})`` to add "content" a new subsection called
   "New section" to an existing section called "Existing section". :pr:`203` by
   `Benjamin Bossan`_.
-- Add an option `use_intelex` to :func:`skops.hub_utils.init` which, when
-  enabled, will result in the Hugging Face inference API running with Intel's
-  scikit-learn intelex library, which can accelerate inference times. :pr:`267`
-  by `Benjamin Bossan`_.
 
 v0.3
 ----

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,10 @@ v0.4
   section/New section": "content"})`` to add "content" a new subsection called
   "New section" to an existing section called "Existing section". :pr:`203` by
   `Benjamin Bossan`_.
+- Add an option `use_intelex` to :func:`skops.hub_utils.init` which, when
+  enabled, will result in the Hugging Face inference API running with Intel's
+  scikit-learn intelex library, which can accelerate inference times. :pr:`267`
+  by `Benjamin Bossan`_.
 
 v0.3
 ----

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -154,6 +154,9 @@ def metadata_from_config(config_path: Union[str, Path]) -> ModelCardData:
     if task:
         card_data.tags += [task]
     card_data.model_file = config.get("sklearn", {}).get("model", {}).get("file")  # type: ignore
+    if config.get("sklearn", {}).get("use_intelex"):
+        card_data.tags.append("scikit-learn-intelex")
+
     example_input = config.get("sklearn", {}).get("example_input", None)
     # Documentation on what the widget expects:
     # https://huggingface.co/docs/hub/models-widgets-examples

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -898,6 +898,38 @@ class TestMetadata:
         for tag in ["sklearn", "skops", "tabular-classification"]:
             assert tag in metadata["tags"]
 
+    def test_metadata_tags_without_sklearn_intelex_tag(
+        self, destination_path, iris_data, iris_pkl_file
+    ):
+        # by default, intelex is not being used
+        X, _ = iris_data
+        hub_utils.init(
+            model=iris_pkl_file,
+            requirements=[],
+            dst=destination_path,
+            task="tabular-classification",
+            data=X,
+        )
+
+        metadata = metadata_from_config(destination_path)
+        assert "scikit-learn-intelex" not in metadata.tags
+
+    def test_metadata_tags_with_sklearn_intelex_tag(
+        self, destination_path, iris_data, iris_pkl_file
+    ):
+        X, _ = iris_data
+        hub_utils.init(
+            model=iris_pkl_file,
+            requirements=[],
+            dst=destination_path,
+            task="tabular-classification",
+            data=X,
+            use_intelex=True,
+        )
+
+        metadata = metadata_from_config(destination_path)
+        assert "scikit-learn-intelex" in metadata.tags
+
 
 @pytest.mark.xfail(reason="dynamic adjustment when model changes not implemented yet")
 class TestModelDynamicUpdate:

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -257,11 +257,12 @@ def _create_config(
         - ``"skops"`` if the extension is ``".skops"``
 
     use_intelex: bool (default=False)
-        Whether to enable scikit-learn-intelex. This can accelerate some sklearn
-        models by a large factor with the right hardware. Enabling this option
-        should not break any code, even if the model was not initially trained
-        with scikit-learn intelex and even if the hardware does not support it.
-        For more info, see https://intel.github.io/scikit-learn-intelex/.
+        Whether to enable ``scikit-learn-intelex``. This can accelerate some
+        sklearn models by a large factor with the right hardware. In most cases,
+        enabling this option should not break any code, even if the model was
+        not initially trained with scikit-learn intelex and even if the hardware
+        does not support it. For more info, see
+        https://intel.github.io/scikit-learn-intelex/.
     """
     # so that we don't have to explicitly add keys and they're added as a
     # dictionary if they are not found
@@ -387,11 +388,12 @@ def init(
         or ``"pickle"``. Defaults to ``"auto"`` that relies on file extension.
 
     use_intelex: bool (default=False)
-        Whether to enable scikit-learn-intelex. This can accelerate some sklearn
-        models by a large factor with the right hardware. Enabling this option
-        should not break any code, even if the model was not initially trained
-        with scikit-learn intelex and even if the hardware does not support it.
-        For more info, see https://intel.github.io/scikit-learn-intelex/.
+        Whether to enable ``scikit-learn-intelex``. This can accelerate some
+        sklearn models by a large factor with the right hardware. In most cases,
+        enabling this option should not break any code, even if the model was
+        not initially trained with scikit-learn intelex and even if the hardware
+        does not support it. For more info, see
+        https://intel.github.io/scikit-learn-intelex/.
     """
     dst = Path(dst)
     if dst.exists() and bool(next(dst.iterdir(), None)):

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -658,3 +658,51 @@ class TestAddFiles:
         )
         with pytest.raises(FileExistsError, match=msg):
             add_files(some_file_0, dst=init_path)
+
+
+class TestUseIntelex:
+    # Tests related to the usage of scikit-learn intelex, see #251
+    def make_config(self, model, requirements, **kwargs):
+        dir_path = tempfile.mkdtemp()
+        shutil.rmtree(dir_path)
+
+        init(
+            model=model,
+            dst=dir_path,
+            task="tabular-classification",
+            data=iris.data,
+            requirements=requirements,
+            **kwargs,
+        )
+        config = get_config(dir_path)
+        return config
+
+    def test_no_intelex(self, classifier):
+        # by default, intelex is not being used
+        config = self.make_config(model=classifier, requirements=["foobar"])
+        environement = config["sklearn"]["environment"]
+
+        assert config["sklearn"]["use_intelex"] is False
+        assert not any(r.startswith("scikit-learn-intelex") for r in environement)
+
+    def test_use_intelex_but_not_explicitly_in_requirements(self, classifier):
+        # when using intelex, if it's not explicitly in the environment, add it
+        # automatically
+        config = self.make_config(
+            model=classifier, requirements=["foobar"], use_intelex=True
+        )
+        environement = config["sklearn"]["environment"]
+
+        assert config["sklearn"]["use_intelex"] is True
+        assert any(r == "scikit-learn-intelex" for r in environement)
+
+    def test_use_intelex_explicitly_in_requirements(self, classifier):
+        # when users specify intelex explicitly, it's not added automatically to
+        # the requirements
+        reqs = ["foobar", "scikit-learn-intelex==2023.0.0"]
+        config = self.make_config(model=classifier, requirements=reqs, use_intelex=True)
+        environement = config["sklearn"]["environment"]
+
+        assert config["sklearn"]["use_intelex"] is True
+        assert not any(r == "scikit-learn-intelex" for r in environement)
+        assert any(r == "scikit-learn-intelex==2023.0.0" for r in environement)


### PR DESCRIPTION
Partially solves #251

This is one part of the work required to solve the mentioned issue. The other part will have to be added on the API inference side, once this PR is finalized.

## Description

Added the option `use_intelex` to `hub_utils.init`. It adds a new entry to `config.json` which can later be used by the inference API to decide whether to run it with intelex or not.

On top of that, if `use_intelex=True`, scikit-learn-intelex will be added as a dependency to the requirements if not already there. Moreover, if metadata for a model card is loaded, a `"scikit-learn-intelex"` tag will be added.