### PR TITLE
MNT Fixes for huggingface_hub 0.12 compatibility

### DIFF
--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -671,8 +671,11 @@ def download(
     if dst.exists():
         dst.rmdir()
 
+    # TODO: Switch from use_auth_token to token once huggingface_hub<0.11 is
+    # dropped. Until then, we ignore the mypy type check, because mypy doesn't
+    # see that use_auth_token is handled by the decorator of snapshot_download.
     cached_folder = snapshot_download(
-        repo_id=repo_id, revision=revision, use_auth_token=token, **kwargs
+        repo_id=repo_id, revision=revision, use_auth_token=token, **kwargs  # type: ignore
     )
     shutil.copytree(cached_folder, dst)
     if not keep_cache:

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -399,10 +399,15 @@ def test_push_download(
         private=True,
     )
 
-    with pytest.raises(
-        RepositoryNotFoundError,
-        match="If the repo is private, make sure you are authenticated.",
-    ):
+    # TODO: remove 1st message when huggingface_hub < v0.12 is dropped
+    # message changes in huggingface_hub v0.12, test both
+    match = (
+        "If the repo is private, make sure you are authenticated"
+        "|"
+        "If you are trying to access a private or gated repo, "
+        "make sure you are authenticated"
+    )
+    with pytest.raises(RepositoryNotFoundError, match=match):
         download(repo_id=repo_id, dst="/tmp/test")
 
     with pytest.raises(OSError, match="None-empty dst path already exists!"):


### PR DESCRIPTION
Following up the discussion in #273

- ignore mypy error in `snapshot_download`
- account for changed error message