### PR TITLE
DOC fix author links

### DIFF
--- a/docs/_authors.rst
+++ b/docs/_authors.rst
@@ -8,3 +8,5 @@
 .. _Benjamin Bossan: https://github.com/BenjaminBossan
 
 .. _Merve Noyan: https://github.com/merveenoyan
+
+.. _Erin Aho: https://github.com/E-Aho

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ v0.5
   and a command line function to convert Pickle files
   to Skops files (:func:`.cli._convert.main`). :pr:`249` by `Erin Aho`_
 - Support more array-like data types for tabular data and list-like data types
-  for text data. :pr:`179` by `Francesco Cariaggi`_.
+  for text data. :pr:`179` by :user:`Francesco Cariaggi <anferico>`.
 - Add an option `use_intelex` to :func:`skops.hub_utils.init` which, when
   enabled, will result in the Hugging Face inference API running with Intel's
   scikit-learn intelex library, which can accelerate inference times. :pr:`267`


### PR DESCRIPTION
The `_authors.rst` file is only for users who contribute often enough that it makes sense to have a short hand link for them. For others we should be using the `:user:` directive.

cc @BenjaminBossan 