### PR TITLE
FIX: Support operators persistence

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ skops Changelog
 
 v0.6
 ----
+- Fix: skops persistence now also works with many functions from the
+  :mod:`operator` module. :pr:`287` by `Benjamin Bossan`_.
 
 v0.5
 ----

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -369,18 +369,6 @@ def object_get_state(obj: Any, save_context: SaveContext) -> dict[str, Any]:
     return res
 
 
-def builtin_function_or_method_state(
-    obj: Any, save_context: SaveContext
-) -> dict[str, Any]:
-    # Some of the functions from the stdlib, like operator.add.
-    res = {
-        "__class__": obj.__name__,
-        "__module__": get_module(obj),
-        "__loader__": "TypeNode",
-    }
-    return res
-
-
 class ObjectNode(Node):
     def __init__(
         self,
@@ -585,7 +573,7 @@ GET_STATE_DISPATCH_FUNCTIONS = [
     (MethodType, method_get_state),
     (partial, partial_get_state),
     (type, type_get_state),
-    (builtin_function_or_method, builtin_function_or_method_state),
+    (builtin_function_or_method, type_get_state),
     (operator.attrgetter, operator_func_get_state),
     (operator.itemgetter, operator_func_get_state),
     (operator.methodcaller, operator_func_get_state),

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -548,7 +548,7 @@ class OperatorFuncNode(Node):
         trusted: bool | Sequence[str] = False,
     ) -> None:
         super().__init__(state, load_context, trusted)
-        self.trusted = self._get_trusted(trusted, [bytes])
+        self.trusted = self._get_trusted(trusted, [])
         self.children["attrs"] = state["attrs"]
 
     def _construct(self):

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -539,7 +539,7 @@ def operator_func_get_state(obj: Any, save_context: SaveContext) -> dict[str, An
         "__class__": obj.__class__.__name__,
         "__module__": "operator",
         "__loader__": "OperatorFuncNode",
-        "attrs": attrs,
+        "attrs": get_state(attrs, save_context),
     }
     return res
 
@@ -553,11 +553,12 @@ class OperatorFuncNode(Node):
     ) -> None:
         super().__init__(state, load_context, trusted)
         self.trusted = self._get_trusted(trusted, [])
-        self.children["attrs"] = state["attrs"]
+        self.children["attrs"] = get_tree(state["attrs"], load_context)
 
     def _construct(self):
         op = getattr(operator, self.class_name)
-        return op(*self.children["attrs"])
+        attrs = self.children["attrs"].construct()
+        return op(*attrs)
 
 
 # <class 'builtin_function_or_method'>

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -3,6 +3,7 @@ import inspect
 import io
 import json
 import operator
+import sys
 import warnings
 from collections import Counter
 from functools import partial, wraps
@@ -890,6 +891,12 @@ OPERATORS = [
     ("truediv", partial(operator.truediv, 1)),
     ("pow", partial(operator.pow, 1)),
     ("matmul", partial(operator.matmul, np.eye(N_SAMPLES))),
+    ("iadd", partial(operator.iadd, 1)),
+    ("isub", partial(operator.isub, 1)),
+    ("imul", partial(operator.imul, 1)),
+    ("itruediv", partial(operator.itruediv, 1)),
+    ("ipow", partial(operator.ipow, 1)),
+    # note: inplace matmul is not supported by numpy
     ("ge", partial(operator.ge, 0)),
     ("gt", partial(operator.gt, 0)),
     ("le", partial(operator.le, 0)),
@@ -903,6 +910,9 @@ OPERATORS = [
     ("methodcaller", operator.methodcaller("round")),
     ("methodcaller", operator.methodcaller("round", 2)),
 ]
+
+if sys.version_info >= (3, 11):
+    OPERATORS.append(("call", partial(operator.call, len)))
 
 
 @pytest.mark.parametrize("op", OPERATORS)


### PR DESCRIPTION
Fixes #283

## Description

Some of the operator functions can be quite useful sklearn users, especially in conjunction with `FunctionTransformer`. This is because it often allows to avoid writing small functions or using `lambda`, which can't be persisted. However, since some of these functions are actually classes defined in CPython that need special treatment, our code didn't work with them.

This fix consists of two parts.

On the one hand, functions like `methodcaller` now have a special dispatch type that knows how to correctly initialize them.

On the other hand, we had a problem with some types like `operator.add`. Since they take 2 arguments, it would be useful for them to be passed without initialization in conjunction with `partial`. However, their type is `builtin_function_or_method`. By default, they would be handled by `object_get_state`, but that doesn't work correctly with uninitialized objects. This has now been fixed by dispatching to `type_get_state`.

## Open questions

To get the type of `operator.add` et al., we need `builtin_function_or_method`. Right now, I just do `builtin_function_or_method = type(len)`. Is there a better way?

Regarding operators like `attrgetter` and `methodcaller`, could there be a security implication by allowing them? Sure, users can decide not to trust that type, but whether it is trustworthy or not depends on its arguments. Right now, we just tell them that they need to trust `_operator.attrgetter`, which could seem harmless. The same argument can of course be made for `eval` & co, but there, users will be much more likely to recognize their danger.