### PR TITLE
ENH: Add possibility to turn section invisible

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -243,16 +243,20 @@ class Section:
     empty string) or a ``Formattable``, which is simply an object with a
     ``format`` method that returns a string.
 
-    Finally, the section can contain subsections, which again are dicts of
+    The section can contain subsections, which again are dicts of
     string keys and section values (the dict can be empty). Therefore, the model
     card representation forms a tree structure, making use of the fact that dict
     order is preserved.
+
+    The section may also contain a ``visible`` flag, which determined if the
+    section will be shown when the card is rendered.
 
     """
 
     title: str
     content: Formattable | str
     subsections: dict[str, Section] = field(default_factory=dict)
+    visible: bool = True
 
     def select(self, key: str) -> Section:
         """Return a subsection or subsubsection of this section
@@ -1182,6 +1186,9 @@ class Card:
 
         """
         for val in data.values():
+            if not val.visible:
+                continue
+
             title = f"{depth * '#'} {val.title}"
             yield title
 

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -248,7 +248,7 @@ class Section:
     card representation forms a tree structure, making use of the fact that dict
     order is preserved.
 
-    The section may also contain a ``visible`` flag, which determined if the
+    The section may also contain a ``visible`` flag, which determines if the
     section will be shown when the card is rendered.
 
     """


### PR DESCRIPTION
Sections of model cards have an additional flag called `visible`. It is by default `True` but if set to `False`, the corresponding section, and its subsections, are not rendered.

In contrast to deleting those section, turning them invisible will not remove them from the underlying data dict. This is useful because it allows us to restore those sections to exactly their previous place. In contrast, if we delete and add them again, they may end up in a different position, because the order of the underlying dict can change.

At the moment, the feature is not used anywhere in skops. I plan, however, to use it for a model card creation space, where it would be quite useful to have.