### PR TITLE
ENH Add performance test + GH action to run it weekly

### DIFF
--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,0 +1,27 @@
+name: HF integration tests
+
+on:
+  schedule:
+    - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check-persistence-performance:
+
+    runs-on: ubuntu-latest
+    # if: "github.repository == 'skops-dev/skops'"
+    if: "github.repository == 'BenjaminBossan/skops'"
+
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install requirements
+      run: |
+        pip install .[tests]
+        pip --version
+        pip list
+    - name: Run persistence performance checks
+      run: python scripts/check_persistence_performance.py

--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -9,8 +9,7 @@ jobs:
   check-persistence-performance:
 
     runs-on: ubuntu-latest
-    # if: "github.repository == 'skops-dev/skops'"
-    if: "github.repository == 'BenjaminBossan/skops'"
+    if: "github.repository == 'skops-dev/skops'"
 
     timeout-minutes: 10
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
         exclude: .github/conda/meta.yaml
@@ -10,20 +10,20 @@ repos:
     -   id: check-case-conflict
     -   id: check-merge-conflict
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     -   id: flake8
         types: [file, python]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v1.0.1
     hooks:
     -   id: mypy
         args: [--config-file=pyproject.toml]

--- a/scripts/check_persistence_performance.py
+++ b/scripts/check_persistence_performance.py
@@ -1,0 +1,94 @@
+"""Check that the performance of skops persistence is not too slow
+
+Load each (fitted) estimator and persist it with pickle and with skops. Measure
+the time it takes and record it. Report the estimators that were slowest. If
+skops is much slower than pickle (in absolute terms), raise an error to make the
+GH action fail.
+
+"""
+
+import pickle
+import timeit
+import warnings
+
+import pandas as pd
+from sklearn.utils._tags import _safe_tags
+from sklearn.utils._testing import set_random_state
+
+import skops.io as sio
+from skops.io.tests.test_persist import (
+    _get_check_estimator_ids,
+    _tested_estimators,
+    get_input,
+)
+
+ATOL = 1  # seconds absolute difference allowed at max
+NUM_REPS = 10  # number of times the check is repeated
+TOPK = 10  # number of slowest estimators reported
+
+
+def check_persist_performance():
+    results = {"name": [], "pickle (s)": [], "skops (s)": []}
+    for estimator in _tested_estimators():
+        set_random_state(estimator, random_state=0)
+
+        X, y = get_input(estimator)
+        tags = _safe_tags(estimator)
+        if tags.get("requires_fit", True):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", module="sklearn")
+                if y is not None:
+                    estimator.fit(X, y)
+                else:
+                    estimator.fit(X)
+
+        name = _get_check_estimator_ids(estimator)
+        time_pickle, time_skops = run_check(estimator, number=NUM_REPS)
+
+        results["name"].append(name)
+        results["pickle (s)"].append(time_pickle)
+        results["skops (s)"].append(time_skops)
+
+    format_result(results, topk=TOPK)
+
+
+def run_check(estimator, number):
+    def run_pickle():
+        pickle.loads(pickle.dumps(estimator))
+
+    def run_skops():
+        sio.loads(sio.dumps(estimator), trusted=True)
+
+    time_pickle = timeit.timeit(run_pickle, number=number) / number
+    time_skops = timeit.timeit(run_skops, number=number) / number
+
+    return time_pickle, time_skops
+
+
+def format_result(results, topk):
+    df = pd.DataFrame(results)
+    df = df.assign(
+        abs_diff=df["skops (s)"] - df["pickle (s)"],
+        rel_diff=df["skops (s)"] / df["pickle (s)"],
+        too_slow=lambda d: d["abs_diff"] > ATOL,
+    )
+
+    df = df.sort_values(["abs_diff"], ascending=False).reset_index(drop=True)
+    print(f"{topk} largest differences:")
+    print(df.head(10))
+
+    df_slow = df.query("too_slow")
+    if df_slow.empty:
+        print("No estimator was found to be unacceptably slow")
+        return
+
+    print(
+        f"Found {len(df_slow)} estimator(s) that are at least {ATOL:.1f} sec slower "
+        "with skops:"
+    )
+    print(", ".join(df_slow["name"].tolist()))
+    raise RuntimeError("Skops persistence too slow")
+
+
+if __name__ == "__main__":
+    check_persist_performance()


### PR DESCRIPTION
Resolves #275 

Ready for review @skops-dev/maintainers 

##  Description

This PR adds a GitHub action that is run on a weekly basis on Sunday. For all
tested sklearn estimators, it persists them once with pickle and once with skops,
and then records the timing difference. If the absolute difference is too large,
an error is raised and we can take a look at what went wrong.

For convenience, that 10 slowest estimators are printed to stdout. That way, we
can find out problematic candidates by looking at the log.

The persistence of an estimator is considered to be too slow when it takes more
than 1 sec longer to persist with skops than with pickle.

## Comments

If someone has a good idea how to test that the GH action is specified correctly
without actually merging it, let me know. For reference, this action is based on
https://github.com/skorch-dev/skorch/pull/904/files, which works.

On top of running the action, we could also add a badge to the README. This
would show at a glance if the last run failed, but it's not strictly necessary.

## Results

Running the script locally, I found these results:

```
10 largest differences:
                                             name  pickle (s)  skops (s)  abs_diff   rel_diff  too_slow
0            ExtraTreesClassifier(random_state=0)    0.003677   0.243817  0.240140  66.312771     False
1       GradientBoostingRegressor(random_state=0)    0.003622   0.243115  0.239493  67.118231     False
2      GradientBoostingClassifier(random_state=0)    0.003112   0.242550  0.239438  77.943117     False
3          RandomForestClassifier(random_state=0)    0.003590   0.236872  0.233282  65.975329     False
4            RandomTreesEmbedding(random_state=0)    0.003292   0.208397  0.205106  63.312033     False
5                 IsolationForest(random_state=0)    0.003295   0.207483  0.204188  62.967271     False
6             ExtraTreesRegressor(random_state=0)    0.003347   0.194232  0.190885  58.030454     False
7           RandomForestRegressor(random_state=0)    0.003112   0.184979  0.181867  59.431591     False
8  HistGradientBoostingClassifier(random_state=0)    0.001690   0.127146  0.125456  75.243695     False
9   HistGradientBoostingRegressor(random_state=0)    0.001283   0.125468  0.124185  97.791886     False
```

So the slowest absolute difference is 0.24 sec, which I think is more than
acceptable. Relative differences can be quite large (100x), which is maybe not
too surprising, given that pickle is highly optimized and skops performs some
extra checks.

According to the criterion described above, none of the estimators is
unacceptably slow, so the action would pass successfully.