### PR TITLE
FIX: setting model_diagram to False after initialization

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -718,13 +718,22 @@ class Card:
 
     @model_diagram.setter
     def model_diagram(self, value: bool) -> None:
+        if self._model_diagram is value:
+            # nothing to change, early return
+            return
+
         self._model_diagram = value
 
         # If we use the skops template, we know what section to add or remove
         # when model_diagram changes values. If not, we don't know and thus need
         # to skip this step.
         if self.template != Templates.skops.value:
-            return
+            msg = (
+                "You are trying to deactivate the model diagram, which does not work "
+                "when using a custom template. Instead, delete the diagram directly by "
+                "calling 'model_card.delete(<name-of-model-diagram-section>)"
+            )
+            raise ValueError(msg)
 
         section_name = "Model description/Training Procedure/Model Plot"
         if not value:  # don't show model diagram

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -288,17 +288,11 @@ class TestAddModelPlot:
     def test_setting_model_diagram_false_custom_template(self, model_card, template):
         model = fit_model()
         model_card = Card(model, template=template, model_diagram=True)
+        model_card.add_model_plot("A beautiful estimator")
 
-        # now set value to False and check that the diagram is no longer shown
-        model_card.model_diagram = False
-        rendered = model_card.render()
-
-        assert "The model plot is below.\n\n<style>#sk-" not in rendered
-        assert "<style>" not in rendered
-        assert (
-            "<pre>LinearRegression()</pre></div></div></div></div></div>"
-            not in rendered
-        )
+        match = "You are trying to deactivate the model diagram"
+        with pytest.raises(ValueError, match=match):
+            model_card.model_diagram = False
 
     def test_setting_model_diagram_false_twice_no_error(self, model_card):
         # check that this does not raise


### PR DESCRIPTION
Resolves #292

When setting `model_card.model_diagram = False`, the rendered model card should not contain the model diagram. For more explanation, see the issue.

The issue is _not_ resolved for the case that a user doesn't use the skops template, because it means we don't know where they put the model diagram and can thus not disable it after they set `model_card.model_diagram = False`. The corresponding test  is marked to `xfail`.

The test suite has been extended to cover more cases around the use of custom templates in conjunction with the model diagram.

