### PR TITLE
MNT: Upgrade mypy to version 1.0.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[docs,tests]
-        pip install black=="22.6.0" isort=="5.10.1" mypy=="0.981"
+        pip install black=="22.6.0" isort=="5.10.1" mypy=="1.0.0"
         pip uninstall --yes scikit-learn
         if [ ${{ matrix.sklearn_version }} == "nightly" ];
           then pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v1.0.0
     hooks:
     -   id: mypy
         args: [--config-file=pyproject.toml]

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 import textwrap
 import zipfile
 from collections.abc import Mapping
@@ -18,6 +19,12 @@ from tabulate import tabulate  # type: ignore
 from skops.card._templates import CONTENT_PLACEHOLDER, SKOPS_TEMPLATE, Templates
 from skops.io import load
 from skops.utils.importutils import import_or_raise
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 # Repr attributes can be used to control the behavior of repr
 aRepr = Repr()
@@ -506,7 +513,7 @@ class Card:
         # model has changed, but at the moment we have no way of knowing that
         return model
 
-    def add(self, **kwargs: str | Formattable) -> Card:
+    def add(self, **kwargs: str | Formattable) -> Self:
         """Add new section(s) to the model card.
 
         Add one or multiple sections to the model card. The section names are
@@ -714,7 +721,7 @@ class Card:
         self,
         section: str | None = None,
         description: str | None = None,
-    ) -> Card:
+    ) -> Self:
         """Add a model plot
 
         Use sklearn model visualization to add create a diagram of the model.
@@ -784,7 +791,7 @@ class Card:
 
     def add_hyperparams(
         self, section: str | None = None, description: str | None = None
-    ) -> Card:
+    ) -> Self:
         """Add the model's hyperparameters as a table
 
         Parameters
@@ -862,7 +869,7 @@ class Card:
         description: str | None = None,
         file_name: str | None = None,
         model_format: Literal["pickle", "skops"] | None = None,
-    ) -> Card:
+    ) -> Self:
         """Add getting started code
 
         This code can be copied by users to load the model and make predictions
@@ -960,7 +967,7 @@ class Card:
 
         self._add_single(section, content)
 
-    def add_plot(self, *, folded=False, **kwargs: str) -> Card:
+    def add_plot(self, *, folded=False, **kwargs: str) -> Self:
         """Add plots to the model card.
 
         The plot should be saved on the file system and the path passed as
@@ -995,7 +1002,7 @@ class Card:
 
     def add_table(
         self, *, folded: bool = False, **kwargs: dict["str", list[Any]]
-    ) -> Card:
+    ) -> Self:
         """Add a table to the model card.
 
         Add a table to the model card. This can be especially useful when you
@@ -1050,7 +1057,7 @@ class Card:
         section: str | None = None,
         description: str | None = None,
         **kwargs: str | int | float,
-    ) -> Card:
+    ) -> Self:
         """Add metric values to the model card.
 
         All metrics will be collected in, and then formatted to, a table.
@@ -1101,7 +1108,7 @@ class Card:
         plot_file: str = "permutation_importances.png",
         plot_name: str = "Permutation Importances",
         overwrite: bool = False,
-    ) -> "Card":
+    ) -> Self:
         """Plots permutation importance and saves it to model card.
 
         Parameters


### PR DESCRIPTION
The upgrade worked out of the box. I made a small change, however, to adjust the signatures of `Card` to return the `Self` type, since this is now correctly recognized by mypy.

Below is an example to illustrate why it's useful:

```python
class Card1:
    def add(self) -> Card1:
        return self

class MyCard1(Card1):
    pass

reveal_type(MyCard1().add())  # returns Card1 but should be MyCard1

class Card2:
    def add(self) -> Self:
        return self

class MyCard2(Card2):
    pass

reveal_type(MyCard2().add())  # returns MyCard2
```

Another advantage of upgrading is that mypy 1.0.0 should be faster. More in [this post](https://mypy-lang.blogspot.com/2023/02/mypy-10-released.html).

Note that pre-commit config has to be updated for this change as well.