### PR TITLE
CI add codecov token to the config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,9 @@ codecov:
   notify:
     after_n_builds: 12
     wait_for_ci: true
+  # the coverage is uploaded with or without a token. This only helps with some
+  # codecov errors. It's a recommended action from here:
+  # https://github.com/codecov/codecov-action/issues/837#issuecomment-1453877750
   token: 2b8d4d69-6de6-4e1d-840a-5ccf9d849565
 ignore:
   - "skops/_min_dependencies.py"  # This file is not tested, and won't be.

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,5 +5,6 @@ codecov:
   notify:
     after_n_builds: 12
     wait_for_ci: true
+  token: 2b8d4d69-6de6-4e1d-840a-5ccf9d849565
 ignore:
   - "skops/_min_dependencies.py"  # This file is not tested, and won't be.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,7 +95,6 @@ jobs:
       with:
         env_vars: OS,PYTHON
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella


### PR DESCRIPTION
The codecov token we have is not actually used in PRs since it's a token on GH, and they're not exposed to `pull_request` triggered actions.

The recommended action seems to be adding it hard coded, which doesn't really pose any security risks: https://github.com/codecov/codecov-action/issues/837#issuecomment-1453877750