### PR TITLE
FIX: issue with fitting TargetEncoder in tests

### DIFF
--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -306,7 +306,9 @@ def get_input(estimator):
         return [(1, 2), (3,)], None
 
     if "categorical" in tags["X_types"]:
-        return [["Male", 1], ["Female", 3], ["Female", 2]], None
+        X = [["Male", 1], ["Female", 3], ["Female", 2]]
+        y = y[: len(X)] if tags["requires_y"] else None
+        return X, y
 
     if "dict" in tags["X_types"]:
         return [{"foo": 1, "bar": 2}, {"foo": 3, "baz": 1}], None


### PR DESCRIPTION
In the persistence tests, the `TargetEncoder` (newly added to sklearn) is fit without a y, which fails. Now it is fitted with y.

The issue was that we assumed that estimators with `"categorical"` X-type never required a target, which was true so far but is no longer true.