### PR TITLE
RFC: Store more objects as pure json

### DIFF
--- a/skops/io/_audit.py
+++ b/skops/io/_audit.py
@@ -154,6 +154,7 @@ class Node:
     ) -> None:
         self.class_name, self.module_name = state["__class__"], state["__module__"]
         self._is_safe = None
+        self._is_json = False  # for pure json objects
         self._constructed = UNINITIALIZED
         saved_id = state.get("__id__")
         if saved_id and memoize:
@@ -237,6 +238,9 @@ class Node:
             # this means we're already computing this node's unsafe set, so we
             # return an empty set and let the computation of the parent node
             # continue. This is to avoid infinite recursion.
+            return set()
+
+        if self._is_json:
             return set()
 
         with temp_setattr(self, _computing_unsafe_set=True):

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -104,12 +104,12 @@ class ReduceNode(Node):
         self.children = {
             "attrs": get_tree(state["content"], load_context),
             "args": get_tree(reduce["args"], load_context),
-            "constructor": constructor,
         }
+        self.constructor = constructor
 
     def _construct(self):
         args = self.children["args"].construct()
-        constructor = self.children["constructor"]
+        constructor = self.constructor
         instance = constructor(*args)
         attrs = self.children["attrs"].construct()
         if not attrs:


### PR DESCRIPTION
## Description

Right now, when using skops persistence, only some primitive types are stored as json: str, numbers, and null. However, in theory we should also be able to store *some* lists and dicts. The advantage of that is that the storage is much more compact, helping with disk size and readability.

One issue is that we need to check if the lists and dicts can indeed be stored as pure json objects. To check this, we make a json roundtrip and verify that the loaded objects still equals the original object. This could of course impact performance.

On top of that, we also need to explicitly check the types. This is because a numpy float will `==` a Python float of the same value, so the json roundtrip might suggest that a dict with numpy floats was restored successfully. But that's not true, we get a Python float back, which is not the same. Checking the types explicitly solves the issue.

The presence of numpy types is, however, also a reason why this feature helps less than I intially thought: Many sklearn objects will store numpy objects as attributes, so their `__dict__` cannot be stored as a pure json object. This is from anecdotal observation, I haven't run the the numbers.

AFAICT, this change should be backwards compatibly, since the old, non "compact" list and dict nodes are still loaded as they were previously.

## Additional

Somewhat unrelatedly, I "fixed" a "bug" where the `constructor` of a `ReduceNode` was stored directly in the node's `children`. This made it so that the object could not be visualized, because the visualization code assumes that all children are nodes. Not sure if we want to make that assumption or not.

## Results

To illustrate how much more compact some objects can be after the change, here is the `state` of `DecisionTreeClassifier`'s `__dict__` with the proposed change:

```python
{'__class__': 'dict',
 '__loader__': 'DictNode',
 '__module__': 'builtins',
 '_is_json': True,
 'content': '{"criterion": "gini", "splitter": "best", "max_depth": 1, '
            '"min_samples_split": 2, "min_samples_leaf": 1, '
            '"min_weight_fraction_leaf": 0.0, "max_features": null, '
            '"max_leaf_nodes": null, "random_state": null, '
            '"min_impurity_decrease": 0.0, "class_weight": null, "ccp_alpha": '
            '0.0, "_sklearn_version": "1.2.2"}'}
```

And this is what it currently looks like:

```python
{'__class__': 'dict',
 '__loader__': 'DictNode',
 '__module__': 'builtins',
 'content': {'_sklearn_version': {'__class__': 'str',
                                  '__id__': 140710339249776,
                                  '__loader__': 'JsonNode',
                                  '__module__': 'builtins',
                                  'content': '"1.2.2"',
                                  'is_json': True},
             'ccp_alpha': {'__class__': 'str',
                           '__id__': 140709199241520,
                           '__loader__': 'JsonNode',
                           '__module__': 'builtins',
                           'content': '0.0',
                           'is_json': True},
             'class_weight': {'__class__': 'str',
                              '__id__': 94259704317888,
                              '__loader__': 'JsonNode',
                              '__module__': 'builtins',
                              'content': 'null',
                              'is_json': True},
             'criterion': {'__class__': 'str',
                           '__id__': 140709195222832,
                           '__loader__': 'JsonNode',
                           '__module__': 'builtins',
                           'content': '"gini"',
                           'is_json': True},
             'max_depth': {'__class__': 'str',
                           '__id__': 140710349848816,
                           '__loader__': 'JsonNode',
                           '__module__': 'builtins',
                           'content': '1',
                           'is_json': True},
             'max_features': {'__class__': 'str',
                              '__id__': 94259704317888,
                              '__loader__': 'JsonNode',
                              '__module__': 'builtins',
                              'content': 'null',
                              'is_json': True},
             'max_leaf_nodes': {'__class__': 'str',
                                '__id__': 94259704317888,
                                '__loader__': 'JsonNode',
                                '__module__': 'builtins',
                                'content': 'null',
                                'is_json': True},
             'min_impurity_decrease': {'__class__': 'str',
                                       '__id__': 140709199241520,
                                       '__loader__': 'JsonNode',
                                       '__module__': 'builtins',
                                       'content': '0.0',
                                       'is_json': True},
             'min_samples_leaf': {'__class__': 'str',
                                  '__id__': 140710349848816,
                                  '__loader__': 'JsonNode',
                                  '__module__': 'builtins',
                                  'content': '1',
                                  'is_json': True},
             'min_samples_split': {'__class__': 'str',
                                   '__id__': 140710349848848,
                                   '__loader__': 'JsonNode',
                                   '__module__': 'builtins',
                                   'content': '2',
                                   'is_json': True},
             'min_weight_fraction_leaf': {'__class__': 'str',
                                          '__id__': 140709199241520,
                                          '__loader__': 'JsonNode',
                                          '__module__': 'builtins',
                                          'content': '0.0',
                                          'is_json': True},
             'random_state': {'__class__': 'str',
                              '__id__': 94259704317888,
                              '__loader__': 'JsonNode',
                              '__module__': 'builtins',
                              'content': 'null',
                              'is_json': True},
             'splitter': {'__class__': 'str',
                          '__id__': 140710325856368,
                          '__loader__': 'JsonNode',
                          '__module__': 'builtins',
                          'content': '"best"',
                          'is_json': True}},
 'key_types': {'__class__': 'list',
               '__id__': 140709182321920,
               '__loader__': 'ListNode',
               '__module__': 'builtins',
               'content': [{'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'},
                           {'__class__': 'str',
                            '__id__': 94259704294976,
                            '__loader__': 'TypeNode',
                            '__module__': 'builtins'}]}}
```

That's 137 lines.

When it comes to visualization, I currently don't treat the node differently if it's for a json object. This is why the visualization may now have very long lines:

```
root: sklearn.ensemble._weight_boosting.AdaBoostClassifier
└── attrs: builtins.dict
    ├── estimator: json-type(null)
    ├── n_estimators: json-type(50)
    ├── estimator_params: builtins.tuple
    ├── base_estimator: json-type("deprecated")
    ├── learning_rate: json-type(1.0)
    ├── random_state: json-type(0)
    ├── algorithm: json-type("SAMME.R")
    ├── n_features_in_: json-type(2)
    ├── estimator_: sklearn.tree._classes.DecisionTreeClassifier
    │   └── attrs: {"criterion": "gini", "splitter": "best", "max_depth": 1, "min_samples_split": 2, "min_samples_leaf": 1, "min_weight_fraction_leaf": 0.0, "max_features": null, "max_leaf_nodes": null, "random_state": null, "min_impurity_decrease": 0.0, "class_weight": null,
"ccp_alpha": 0.0, "_sklearn_version": "1.2.2"}
# etc.
```

Before, it looked like this:

```
root: sklearn.ensemble._weight_boosting.AdaBoostClassifier
└── attrs: builtins.dict
    ├── estimator: json-type(null)
    ├── n_estimators: json-type(50)
    ├── estimator_params: builtins.tuple
    ├── base_estimator: json-type("deprecated")
    ├── learning_rate: json-type(1.0)
    ├── random_state: json-type(0)
    ├── algorithm: json-type("SAMME.R")
    ├── n_features_in_: json-type(2)
    ├── estimator_: sklearn.tree._classes.DecisionTreeClassifier
    │   └── attrs: builtins.dict
    │       ├── criterion: json-type("gini")
    │       ├── splitter: json-type("best")
    │       ├── max_depth: json-type(1)
    │       ├── min_samples_split: json-type(2)
    │       ├── min_samples_leaf: json-type(1)
    │       ├── min_weight_fraction_leaf: json-type(0.0)
    │       ├── max_features: json-type(null)
    │       ├── max_leaf_nodes: json-type(null)
    │       ├── random_state: json-type(null)
    │       ├── min_impurity_decrease: json-type(0.0)
    │       ├── class_weight: json-type(null)
    │       ├── ccp_alpha: json-type(0.0)
    │       └── _sklearn_version: json-type("1.2.2")
# etc.
```