### PR TITLE
RFC: Persist more objs as pure json

### DIFF
--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -25,7 +25,7 @@ def ndarray_get_state(obj: Any, save_context: SaveContext) -> dict[str, Any]:
         # recursively call get_state on it.
         if obj.dtype == object:
             obj_serialized = get_state(obj.tolist(), save_context)
-            res["content"] = obj_serialized["content"]
+            res["content"] = obj_serialized
             res["type"] = "json"
             res["shape"] = get_state(obj.shape, save_context)
         else:
@@ -67,9 +67,7 @@ class NdArrayNode(Node):
             }
         elif self.type == "json":
             self.children = {
-                "content": [  # type: ignore
-                    get_tree(o, load_context) for o in state["content"]  # type: ignore
-                ],
+                "content": get_tree(state["content"], load_context),
                 "shape": get_tree(state["shape"], load_context),
             }
         else:
@@ -87,7 +85,7 @@ class NdArrayNode(Node):
             # We explicitly set the dtype to "O" since we only save object
             # arrays in json.
             shape = self.children["shape"].construct()
-            tmp = [o.construct() for o in self.children["content"]]
+            tmp = self.children["content"].construct()
 
             # TODO: this is a hack to get the correct shape of the array. We
             # should find _a better way_ to do this.

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -104,12 +104,12 @@ class ReduceNode(Node):
         self.children = {
             "attrs": get_tree(state["content"], load_context),
             "args": get_tree(reduce["args"], load_context),
-            "constructor": constructor,
         }
+        self.constructor = constructor
 
     def _construct(self):
         args = self.children["args"].construct()
-        constructor = self.children["constructor"]
+        constructor = self.constructor
         instance = constructor(*args)
         attrs = self.children["attrs"].construct()
         if not attrs:

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -536,7 +536,7 @@ def test_metainfo():
     # additionally, check following metainfo: class, module, and version
     expected = {
         "builtin_": {
-            "__class__": "list",
+            "__class__": "str",
             "__module__": "builtins",
         },
         "stdlib_": {
@@ -853,14 +853,15 @@ def test_dump_and_load_with_file_wrapper(tmp_path):
     "obj",
     [
         np.array([1, 2]),
-        [1, 2, 3],
         {1: 1, 2: 2},
-        {1, 2, 3},
-        "A string",
+        {1, 2, "3"},
         np.random.RandomState(42),
     ],
 )
 def test_when_given_object_referenced_twice_loads_as_one_object(obj):
+    # note: memoizing will not work if 'obj' is json-serializable, because then
+    # the whole object will be json-serialized, individual fields are not
+    # memoized.
     an_object = {"obj_1": obj, "obj_2": obj}
     persisted_object = loads(dumps(an_object), trusted=True)
 


### PR DESCRIPTION
Alternative to #334 

@skops-dev/maintainers RFC

The two implementations result in the same outcome but are implemented differently: This one checks during `get_state` if we can use pure json and if so, returns a state that will be loaded with `JsonNode`. The other implementation will not dispatch to other `get_state` functions, instead the different nodes (`JsonNode`, `DictNode`, `ListNode`) will take care of loading the json if applicable.

I think this implementation is cleaner than the other one. A disadvantage of this implementation is that there needed to be a change in how numpy object dtype arrays are persisted, which will require a protocol change.

RFC, especially regarding:

1. Do we want to go down any of these paths?
2. If so, is this implementation better or #334?
3. Anything that could be improved?

## Description

Right now, when using skops persistence, only some primitive types are stored as json: str, numbers, and null. However, in theory we should also be able to store some lists and dicts. The advantage of that is that the storage is much more compact, helping with disk size and readability.

One issue is that we need to check if the lists and dicts can indeed be stored as pure json objects. To check this, we make a json roundtrip and verify that the loaded objects still equals the original object.

On top of that, we also need to explicitly check the types. This is because a numpy float will == a Python float of the same value, so the json roundtrip might suggest that a dict with numpy floats was restored successfully. But that's not true, we get a Python float back, which is not the same. Checking the types explicitly solves the issue.

The presence of numpy types is, however, also a reason why this feature helps less than I intially thought: Many sklearn objects will store numpy objects as attributes, so their __dict__ cannot be stored as a pure json object.

## Metrics

### Disk size

I stored the dumped objects on disk, once with main and once with this refactor:

```
$ du .
1000	./refactor-unfitted
1564	./normal-unfitted
22856	./normal-fitted
22664	./refactor-fitted
```

As can be seen, for unfitted objects, we get 1/3 reduction in size, but for fitted objects, there is no significant difference. This confirms the suspicion that for fitted objects, we almost always have some numpy types or something else that would prevent a pure json object.

The largest objects are all based on ensembles of trees, and since those are not json-serializable, there is no size benefit. For smaller objects, there is a consistent size reduction with the refactored code.

### Speed

I ran the `check_persistence_performance.py` script to check if we see a speed regression.

Before refactor:

```
10 largest differences:
                             name  pickle (s)  skops (s)  abs_diff   rel_diff
0      GradientBoostingClassifier    0.003439   0.254904  0.251465  74.130723
1            ExtraTreesClassifier    0.003807   0.243327  0.239520  63.909274
2       GradientBoostingRegressor    0.003362   0.242606  0.239244  72.170761
3          RandomForestClassifier    0.003718   0.235812  0.232094  63.424460
4                 IsolationForest    0.003818   0.214642  0.210824  56.219939
5            RandomTreesEmbedding    0.003389   0.209714  0.206325  61.883283
6             ExtraTreesRegressor    0.003325   0.202813  0.199488  60.994368
7           RandomForestRegressor    0.003200   0.185760  0.182561  58.057241
8  HistGradientBoostingClassifier    0.001485   0.134543  0.133058  90.599054
9   HistGradientBoostingRegressor    0.001372   0.130100  0.128728  94.794223
No estimator was found to be unacceptably slow

```

After:

```
10 largest differences:
                             name  pickle (s)  skops (s)  abs_diff   rel_diff
0      GradientBoostingClassifier    0.003333   0.252640  0.249307  75.802290
1       GradientBoostingRegressor    0.003426   0.251955  0.248529  73.539743
2            ExtraTreesClassifier    0.004077   0.250550  0.246473  61.452242
3          RandomForestClassifier    0.003669   0.242138  0.238469  65.987126
4                 IsolationForest    0.003406   0.212873  0.209466  62.496016
5            RandomTreesEmbedding    0.003437   0.212860  0.209423  61.939385
6             ExtraTreesRegressor    0.003329   0.195246  0.191918  58.655659
7           RandomForestRegressor    0.003228   0.189995  0.186767  58.860496
8   HistGradientBoostingRegressor    0.001317   0.127843  0.126526  97.072401
9  HistGradientBoostingClassifier    0.001313   0.126494  0.125180  96.315720
No estimator was found to be unacceptably slow
```

No significant differences here.

### Readability

Using `visualize`, arguably the new variant is a bit less readable when there is a big json object, though one could argue that those are always safe so closer inspection is not necessary (we might want to truncate thos). One reason for that is the `visualize` function already takes care of removing noise.

Below are the results for an unfitted `DecisionTreeClassifier`:

Before:

```
root: sklearn.tree._classes.DecisionTreeClassifier
└── attrs: builtins.dict
    ├── criterion: json-type("gini")
    ├── splitter: json-type("best")
    ├── max_depth: json-type(null)
    ├── min_samples_split: json-type(2)
    ├── min_samples_leaf: json-type(1)
    ├── min_weight_fraction_leaf: json-type(0.0)
    ├── max_features: json-type(null)
    ├── max_leaf_nodes: json-type(null)
    ├── random_state: json-type(0)
    ├── min_impurity_decrease: json-type(0.0)
    ├── class_weight: json-type(null)
    ├── ccp_alpha: json-type(0.0)
    └── _sklearn_version: json-type("1.2.2")
```

After:

```
root: sklearn.tree._classes.DecisionTreeClassifier
└── attrs: json-type({"criterion": "gini", "splitter": "best", "max_depth": null, "min_samples_split": 2, "min_samples_leaf": 1, "min_weight_fraction_leaf": 0.0, "max_features": null, "max_leaf_nodes": null, "random_state": 0, "min_impurity_decrease": 0.0, "class_weight": 
null, "ccp_alpha": 0.0, "_sklearn_version": "1.2.2"})
```

For the schema itself, the difference is quite big though. Before:

```
{'__class__': 'DecisionTreeClassifier',
 '__id__': 140451943710096,
 '__loader__': 'ObjectNode',
 '__module__': 'sklearn.tree._classes',
 'content': {'__class__': 'dict',
             '__id__': 140450810121792,
             '__loader__': 'DictNode',
             '__module__': 'builtins',
             'content': {'_sklearn_version': {'__class__': 'str',
                                              '__id__': 140451943909104,
                                              '__loader__': 'JsonNode',
                                              '__module__': 'builtins',
                                              'content': '"1.2.2"',
                                              'is_json': True},
                         'ccp_alpha': {'__class__': 'str',
                                       '__id__': 140450862391504,
                                       '__loader__': 'JsonNode',
                                       '__module__': 'builtins',
                                       'content': '0.0',
                                       'is_json': True},
                         'class_weight': {'__class__': 'str',
                                          '__id__': 94237493811136,
                                          '__loader__': 'JsonNode',
                                          '__module__': 'builtins',
                                          'content': 'null',
                                          'is_json': True},
                         'criterion': {'__class__': 'str',
                                       '__id__': 140450799343856,
                                       '__loader__': 'JsonNode',
                                       '__module__': 'builtins',
                                       'content': '"gini"',
                                       'is_json': True},
                         'max_depth': {'__class__': 'str',
                                       '__id__': 94237493811136,
                                       '__loader__': 'JsonNode',
                                       '__module__': 'builtins',
                                       'content': 'null',
                                       'is_json': True},
                         'max_features': {'__class__': 'str',
                                          '__id__': 94237493811136,
                                          '__loader__': 'JsonNode',
                                          '__module__': 'builtins',
                                          'content': 'null',
                                          'is_json': True},
                         'max_leaf_nodes': {'__class__': 'str',
                                            '__id__': 94237493811136,
                                            '__loader__': 'JsonNode',
                                            '__module__': 'builtins',
                                            'content': 'null',
                                            'is_json': True},
                         'min_impurity_decrease': {'__class__': 'str',
                                                   '__id__': 140450862391504,
                                                   '__loader__': 'JsonNode',
                                                   '__module__': 'builtins',
                                                   'content': '0.0',
                                                   'is_json': True},
                         'min_samples_leaf': {'__class__': 'str',
                                              '__id__': 140451945382128,
                                              '__loader__': 'JsonNode',
                                              '__module__': 'builtins',
                                              'content': '1',
                                              'is_json': True},
                         'min_samples_split': {'__class__': 'str',
                                               '__id__': 140451945382160,
                                               '__loader__': 'JsonNode',
                                               '__module__': 'builtins',
                                               'content': '2',
                                               'is_json': True},
                         'min_weight_fraction_leaf': {'__class__': 'str',
                                                      '__id__': 140450862391504,
                                                      '__loader__': 'JsonNode',
                                                      '__module__': 'builtins',
                                                      'content': '0.0',
                                                      'is_json': True},
                         'random_state': {'__class__': 'str',
                                          '__id__': 140451945382096,
                                          '__loader__': 'JsonNode',
                                          '__module__': 'builtins',
                                          'content': '0',
                                          'is_json': True},
                         'splitter': {'__class__': 'str',
                                      '__id__': 140451931580208,
                                      '__loader__': 'JsonNode',
                                      '__module__': 'builtins',
                                      'content': '"best"',
                                      'is_json': True}},
             'key_types': {'__class__': 'list',
                           '__id__': 140450788312704,
                           '__loader__': 'ListNode',
                           '__module__': 'builtins',
                           'content': [{'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'},
                                       {'__class__': 'str',
                                        '__id__': 94237493788224,
                                        '__loader__': 'TypeNode',
                                        '__module__': 'builtins'}]}}}
```

After:

```
{'__class__': 'DecisionTreeClassifier',
 '__id__': 140560901242256,
 '__loader__': 'ObjectNode',
 '__module__': 'sklearn.tree._classes',
 'content': {'__class__': 'str',
             '__id__': 140559769484800,
             '__loader__': 'JsonNode',
             '__module__': 'builtins',
             'content': '{"criterion": "gini", "splitter": "best", '
                        '"max_depth": null, "min_samples_split": 2, '
                        '"min_samples_leaf": 1, "min_weight_fraction_leaf": '
                        '0.0, "max_features": null, "max_leaf_nodes": null, '
                        '"random_state": 0, "min_impurity_decrease": 0.0, '
                        '"class_weight": null, "ccp_alpha": 0.0, '
                        '"_sklearn_version": "1.2.2"}',
             'is_json': True}}
```

