### PR TITLE
#224: trusting np.ufuncs and np.dtypes

### DIFF
--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -13,6 +13,8 @@ import numpy as np
 from ._audit import Node, get_tree
 from ._protocol import PROTOCOL
 from ._trusted_types import (
+    NUMPY_DTYPE_TYPE_NAMES,
+    NUMPY_UFUNC_TYPE_NAMES,
     PRIMITIVE_TYPE_NAMES,
     SCIPY_UFUNC_TYPE_NAMES,
     SKLEARN_ESTIMATOR_TYPE_NAMES,
@@ -197,7 +199,9 @@ class FunctionNode(Node):
     ) -> None:
         super().__init__(state, load_context, trusted)
         # TODO: what do we trust?
-        self.trusted = self._get_trusted(trusted, default=SCIPY_UFUNC_TYPE_NAMES)
+        self.trusted = self._get_trusted(
+            trusted, default=SCIPY_UFUNC_TYPE_NAMES + NUMPY_UFUNC_TYPE_NAMES
+        )
         self.children = {}
 
     def _construct(self):
@@ -278,7 +282,9 @@ class TypeNode(Node):
     ) -> None:
         super().__init__(state, load_context, trusted)
         # TODO: what do we trust?
-        self.trusted = self._get_trusted(trusted, PRIMITIVE_TYPE_NAMES)
+        self.trusted = self._get_trusted(
+            trusted, PRIMITIVE_TYPE_NAMES + NUMPY_DTYPE_TYPE_NAMES
+        )
         # We use a bare Node type here since a Node only checks the type in the
         # dict using __class__ and __module__ keys.
         self.children = {}

--- a/skops/io/_numpy.py
+++ b/skops/io/_numpy.py
@@ -8,6 +8,7 @@ import numpy as np
 from ._audit import Node, get_tree
 from ._general import function_get_state
 from ._protocol import PROTOCOL
+from ._trusted_types import NUMPY_DTYPE_TYPE_NAMES
 from ._utils import LoadContext, SaveContext, get_module, get_state, gettype
 from .exceptions import UnsupportedTypeException
 
@@ -60,7 +61,7 @@ class NdArrayNode(Node):
     ) -> None:
         super().__init__(state, load_context, trusted)
         self.type = state["type"]
-        self.trusted = self._get_trusted(trusted, [np.ndarray])
+        self.trusted = self._get_trusted(trusted, [np.ndarray] + NUMPY_DTYPE_TYPE_NAMES)
         if self.type == "numpy":
             self.children = {
                 "content": io.BytesIO(load_context.src.read(state["file"]))

--- a/skops/io/_trusted_types.py
+++ b/skops/io/_trusted_types.py
@@ -24,3 +24,25 @@ SCIPY_UFUNC_TYPE_NAMES = sorted(
         ]
     )
 )
+
+NUMPY_UFUNC_TYPE_NAMES = sorted(
+    set(
+        [
+            get_type_name(getattr(np, attr))
+            for attr in dir(np)
+            if isinstance(getattr(np, attr), np.ufunc)
+            and get_type_name(getattr(np, attr)).startswith("numpy")
+        ]
+    )
+)
+
+NUMPY_DTYPE_TYPE_NAMES = sorted(
+    set(
+        [
+            get_type_name(dtype)
+            for dtypes in np.sctypes.values()
+            for dtype in dtypes
+            if get_type_name(dtype).startswith("numpy")
+        ]
+    )
+)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/skops-dev/skops/blob/main/CONTRIBUTING.rst
This guideline contains crucial information for your PR to be merged, such as setting up
development environment or linting your code.
-->

#### Reference Issues/PRs
closes #224 


#### What does this implement/fix? Explain your changes.
Trusting `numpy.ufuncs` and `numpy.dtypes` by default.

#### Any other comments?
1. I compared the ufuncs list obtained in this PR with the [available ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html#available-ufuncs). They are almost the same except the aliases. Take `true_divide` as an example that is an alias for `divide` and unfortunately cannot be found with the `dir(...)` and `isinstance(...)` approach. Is there a way to find numpy aliases ?
2. `test_can_persist_fitted` didn't run successfully until I added `NUMPY_DTYPE_TYPE_NAMES` to the default trusted list of `NdArrayNode`. I am wondering why isn't `DTypeNode` the correct place ? Is there any other Nodes I am missing ?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy.

Thanks for contributing!
-->
