### PR TITLE
TST Check file size differences

### DIFF
--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,4 +1,4 @@
-name: Test performance of skops persistence
+name: Test performance and file size of skops persistence
 
 on:
   schedule:
@@ -26,3 +26,5 @@ jobs:
         pip list
     - name: Run persistence performance checks
       run: python scripts/check_persistence_performance.py
+    - name: Run file size checks
+      run: python scripts/check_file_size.py

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -1,0 +1,112 @@
+"""Check that the file size of skops files is not too large.
+
+Load each (fitted) estimator and persist it with pickle and with skops. Measure
+the file size of the resulting files. Report the results but in contrast to the
+runtime check, don't raise any errors if the file size differences is too big.
+
+For skops, zip compression is applied. This is because we can assume that if a
+user really cares about file size, they will compress the file.
+
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import warnings
+from tempfile import mkstemp
+from typing import Any
+from zipfile import ZIP_DEFLATED
+
+import pandas as pd
+from sklearn.utils._tags import _safe_tags
+from sklearn.utils._testing import set_random_state
+
+import skops.io as sio
+from skops.io.tests.test_persist import (
+    _get_check_estimator_ids,
+    _tested_estimators,
+    get_input,
+)
+
+TOPK = 10  # number of largest estimators reported
+
+
+def check_file_size() -> None:
+    """Run all file size checks on all estimators and report the results.
+
+    Print the results twice, once sorted by absolute differences, once sorted by
+    relative differences.
+
+    """
+    results: dict[str, list[Any]] = {"name": [], "pickle (kb)": [], "skops (kb)": []}
+    for estimator in _tested_estimators():
+        set_random_state(estimator, random_state=0)
+
+        X, y = get_input(estimator)
+        tags = _safe_tags(estimator)
+        if tags.get("requires_fit", True):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", module="sklearn")
+                if y is not None:
+                    estimator.fit(X, y)
+                else:
+                    estimator.fit(X)
+
+        name = _get_check_estimator_ids(estimator)
+        cls_name, _, _ = name.partition("(")
+        size_pickle, size_skops = run_check(estimator)
+
+        results["name"].append(cls_name)
+        results["pickle (kb)"].append(size_pickle)
+        results["skops (kb)"].append(size_skops)
+
+    format_result(results, topk=TOPK)
+
+
+def run_check(estimator) -> tuple[float, float]:
+    """Run file size check with the given estimator for pickle and skops."""
+    _, name = mkstemp(prefix="skops")
+
+    def run_pickle():
+        fname = name + ".pickle"
+        with open(fname, "wb") as f:
+            pickle.dump(estimator, f)
+        # return size in kb
+        return os.stat(fname).st_size / 1024
+
+    def run_skops():
+        fname = name + ".skops"
+        sio.dump(estimator, fname, compression=ZIP_DEFLATED, compresslevel=9)
+        # return size in kb
+        return os.stat(fname).st_size / 1024
+
+    size_pickle = run_pickle()
+    size_skops = run_skops()
+    return size_pickle, size_skops
+
+
+def format_result(results: dict[str, list[Any]], topk: int) -> None:
+    """Report results from performance checks.
+
+    Print the largest file size differences between pickle and skops, once for
+    absolute, once for relative differences.
+
+    """
+    df = pd.DataFrame(results)
+    df = df.assign(
+        abs_diff=df["skops (kb)"] - df["pickle (kb)"],
+        rel_diff=df["skops (kb)"] / df["pickle (kb)"],
+    )
+
+    dfs = df.sort_values(["abs_diff"], ascending=False).reset_index(drop=True)
+    print(f"{topk} largest absolute differences:")
+    print(dfs[["name", "pickle (kb)", "skops (kb)", "abs_diff"]].head(10))
+
+    print(f"{topk} largest relative differences:")
+    dfs = df.sort_values(["rel_diff"], ascending=False).reset_index(drop=True)
+    print(dfs[["name", "pickle (kb)", "skops (kb)", "rel_diff"]].head(10))
+
+
+if __name__ == "__main__":
+    check_file_size()


### PR DESCRIPTION
## Description

We already measure the runtime performance difference, but we don't check the file size difference. This PR adds another, similar script that does exactly that. The checks are run in the same workflow as the runtime performance checks.

The results are reported, showing top 10 largest differences, once in terms of absolute, once in terms of relative differences. In contrast to the runtime performance check, there is never any error raised, no matter how big the difference is, because it is unclear what, if any, difference, would count as unacceptable.

I compressed the pickle and skops files with a high compression rate. This is a reasonable choice for the benchmark because we can assume that if file size is a concern, users would choose that option.

## Results

Running this on my machine, I get:

### Largest absolute difference

```
                             name  pickle (kb)  skops (kb)    abs_diff
0      GradientBoostingClassifier    28.260742  401.458008  373.197266
1       GradientBoostingRegressor    26.522461  398.620117  372.097656
2            ExtraTreesClassifier    55.287109  204.671875  149.384766
3             ExtraTreesRegressor   155.334961  299.827148  144.492188
4          RandomForestClassifier    21.762695  158.903320  137.140625
5                 IsolationForest    83.681641  218.454102  134.772461
6            RandomTreesEmbedding    66.018555  193.952148  127.933594
7           RandomForestRegressor    96.218750  218.662109  122.443359
8  HistGradientBoostingClassifier    12.216797   95.233398   83.016602
9   HistGradientBoostingRegressor    12.311523   94.998047   82.686523
```

### Largest relative difference

```
                             name  pickle (kb)  skops (kb)   rel_diff
0       GradientBoostingRegressor    26.522461  398.620117  15.029530
1      GradientBoostingClassifier    28.260742  401.458008  14.205501
2              AdaBoostClassifier     5.845703   68.863281  11.780154
3                       SparsePCA     1.147461   11.383789   9.920851
4                  FactorAnalysis     1.434570   11.860352   8.267529
5                KBinsDiscretizer     1.763672   14.403320   8.166667
6  HistGradientBoostingClassifier    12.216797   95.233398   7.795284
7   HistGradientBoostingRegressor    12.311523   94.998047   7.716189
8                   CategoricalNB     1.371094   10.341797   7.542735
9          RandomForestClassifier    21.762695  158.903320   7.301638
```

Out of curiosity, I also sorted by the lowest difference and there the factor could be as small as skops being 4% larger. The mean relative difference is skops being 137% larger, median is 92% larger.

The largest differences are clearly found in decision tree ensemble estimators. This is perhaps not surprising, given that those should be the largest models in general, with 100 trees by default. Still, perhaps we can come up with a way to store trees more efficiently.