### PR TITLE
Add trust check to persistence performance test

### DIFF
--- a/scripts/check_persistence_performance.py
+++ b/scripts/check_persistence_performance.py
@@ -75,7 +75,10 @@ def run_check(estimator, number: int) -> tuple[float, float]:
         pickle.loads(pickle.dumps(estimator))
 
     def run_skops():
-        sio.loads(sio.dumps(estimator), trusted=True)
+        # measure time including the check of untrusted types
+        dumped = sio.dumps(estimator)
+        trusted = sio.get_untrusted_types(data=dumped)
+        sio.loads(dumped, trusted=trusted)
 
     time_pickle = timeit.timeit(run_pickle, number=number) / number
     time_skops = timeit.timeit(run_skops, number=number) / number


### PR DESCRIPTION
## Description

Our script to check that skops persistence is not too slow compared to pickle used `trusted=True` so far. However, this is not the recommended way of using skops -- ideally the check for trusted types should be performed, which theoretically could slow down persistence. This PR adds the check for trusted types to the script.

## Results

Testing locally, there is only a small difference. For instance, for the slowest couple of tests, the added time was only 0.05 sec or less. On average across all estimators, the difference was 0.004 sec. or 30% slower. This relatively small increase means that the check for trusted types is fast compared to constructing the objects.