### PR TITLE
FIX: bug when visualizing byte nodes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Tests
       env:
         SUPER_SECRET: ${{ secrets.HF_HUB_TOKEN }}
+        PYTHONIOENCODING: "utf-8"
       run: |
         python -m pytest -s -v --cov-report=xml -m "not inference" skops/
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,8 @@ v0.7
 - `compression` and `compresslevel` from :class:`~zipfile.ZipFile` are now
   exposed to the user via :func:`.io.dumps` and :func:`.io.dump`. :pr:`345` by
   `Adrin Jalali`_.
+- Fix: :func:`skops.io.visualize` is now capable of showing bytes. :pr:`352` by
+  `Benjamin Bossan`_.
 
 v0.6
 ----

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -532,14 +532,8 @@ class BytesNode(Node):
         return content
 
     def format(self):
-        try:
-            content = self.children["content"].getvalue()
-            byte_repr = arepr.repr(content)
-        except Exception:
-            byte_repr = "b'...'"
-        finally:
-            # ensure that no matter what happens, the file pointer is reset
-            self.children["content"].seek(0)
+        content = self.children["content"].getvalue()
+        byte_repr = arepr.repr(content)
         return byte_repr
 
 

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -8,10 +8,20 @@ from typing import Any, Callable, Iterator, Literal, Sequence
 from zipfile import ZipFile
 
 from ._audit import VALID_NODE_CHILD_TYPES, Node, get_tree
-from ._general import FunctionNode, JsonNode, ListNode
+from ._general import BytearrayNode, BytesNode, FunctionNode, JsonNode, ListNode
 from ._numpy import NdArrayNode
 from ._scipy import SparseMatrixNode
 from ._utils import LoadContext
+
+# The children of these types are not visualized
+SKIPPED_TYPES = (
+    BytearrayNode,
+    BytesNode,
+    FunctionNode,
+    JsonNode,
+    NdArrayNode,
+    SparseMatrixNode,
+)
 
 
 @dataclass
@@ -269,7 +279,7 @@ def walk_tree(
     # TODO: For better security, we should check the schema if we return early,
     # otherwise something nefarious could be hidden inside (however, if there
     # is, the node should be marked as unsafe)
-    if isinstance(node, (NdArrayNode, SparseMatrixNode, FunctionNode, JsonNode)):
+    if isinstance(node, SKIPPED_TYPES):
         return
 
     yield from walk_tree(

--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -54,6 +54,11 @@ def rank_data(clf_data):
     return X, y, group
 
 
+def _null(*args, **kwargs):
+    # used to prevent printing anything to stdout when calling visualize
+    return
+
+
 class TestLightGBM:
     """Tests for LGBMClassifier, LGBMRegressor, LGBMRanker"""
 
@@ -95,7 +100,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, lgbm, regr_data, trusted, boosting_type):
@@ -114,7 +119,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, lgbm, rank_data, trusted, boosting_type):
@@ -133,7 +138,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
 
 class TestXGBoost:
@@ -191,7 +196,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -210,7 +215,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -229,7 +234,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -248,7 +253,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -267,7 +272,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
 
 class TestCatboost:
@@ -326,7 +331,7 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, catboost, cb_regr_data, trusted, boosting_type):
@@ -342,7 +347,7 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, catboost, cb_rank_data, trusted, boosting_type):
@@ -358,4 +363,4 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted, sink=_null)

--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -12,6 +12,8 @@ with a range of hyperparameters.
 
 """
 
+from unittest.mock import Mock, patch
+
 import pytest
 from sklearn.datasets import make_classification, make_regression
 
@@ -54,13 +56,16 @@ def rank_data(clf_data):
     return X, y, group
 
 
-def _null(*args, **kwargs):
-    # used to prevent printing anything to stdout when calling visualize
-    return
-
-
 class TestLightGBM:
     """Tests for LGBMClassifier, LGBMRegressor, LGBMRanker"""
+
+    @pytest.fixture(autouse=True)
+    def capture_stdout(self):
+        # Mock print and rich.print so that running these tests with pytest -s
+        # does not spam stdout. Other, more common methods of suppressing
+        # printing to stdout don't seem to work, perhaps because of pytest.
+        with patch("builtins.print", Mock()), patch("rich.print", Mock()):
+            yield
 
     @pytest.fixture(autouse=True)
     def lgbm(self):
@@ -100,7 +105,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, lgbm, regr_data, trusted, boosting_type):
@@ -119,7 +124,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, lgbm, rank_data, trusted, boosting_type):
@@ -138,7 +143,7 @@ class TestLightGBM:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
 
 class TestXGBoost:
@@ -157,6 +162,14 @@ class TestXGBoost:
     avoid testing these cases. See https://github.com/dmlc/xgboost/issues/8596
 
     """
+
+    @pytest.fixture(autouse=True)
+    def capture_stdout(self):
+        # Mock print and rich.print so that running these tests with pytest -s
+        # does not spam stdout. Other, more common methods of suppressing
+        # printing to stdout don't seem to work, perhaps because of pytest.
+        with patch("builtins.print", Mock()), patch("rich.print", Mock()):
+            yield
 
     @pytest.fixture(autouse=True)
     def xgboost(self):
@@ -196,7 +209,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -215,7 +228,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -234,7 +247,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -253,7 +266,7 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -272,11 +285,19 @@ class TestXGBoost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
 
 class TestCatboost:
     """Tests for CatBoostClassifier, CatBoostRegressor, and CatBoostRanker"""
+
+    @pytest.fixture(autouse=True)
+    def capture_stdout(self):
+        # Mock print and rich.print so that running these tests with pytest -s
+        # does not spam stdout. Other, more common methods of suppressing
+        # printing to stdout don't seem to work, perhaps because of pytest.
+        with patch("builtins.print", Mock()), patch("rich.print", Mock()):
+            yield
 
     # CatBoost data is a little different so that it works as categorical data
     @pytest.fixture(scope="module")
@@ -331,7 +352,7 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, catboost, cb_regr_data, trusted, boosting_type):
@@ -347,7 +368,7 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, catboost, cb_rank_data, trusted, boosting_type):
@@ -363,4 +384,4 @@ class TestCatboost:
         loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
 
-        visualize(dumped, trusted=trusted, sink=_null)
+        visualize(dumped, trusted=trusted)

--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -2,12 +2,20 @@
 
 Packages that are not builtins, standard lib, numpy, scipy, or scikit-learn.
 
+Testing:
+
+- persistence of unfitted models
+- persistence of fitted models
+- visualization of dumped models
+
+with a range of hyperparameters.
+
 """
 
 import pytest
 from sklearn.datasets import make_classification, make_regression
 
-from skops.io import dumps, loads
+from skops.io import dumps, loads, visualize
 from skops.io.tests._utils import assert_method_outputs_equal, assert_params_equal
 
 # Default settings for generated data
@@ -83,8 +91,11 @@ class TestLightGBM:
 
         X, y = clf_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, lgbm, regr_data, trusted, boosting_type):
@@ -99,8 +110,11 @@ class TestLightGBM:
 
         X, y = regr_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, lgbm, rank_data, trusted, boosting_type):
@@ -115,8 +129,11 @@ class TestLightGBM:
 
         X, y, group = rank_data
         estimator.fit(X, y, group=group)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
 
 class TestXGBoost:
@@ -170,8 +187,11 @@ class TestXGBoost:
 
         X, y = clf_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -186,8 +206,11 @@ class TestXGBoost:
 
         X, y = regr_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -202,8 +225,11 @@ class TestXGBoost:
 
         X, y = clf_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -218,8 +244,11 @@ class TestXGBoost:
 
         X, y = regr_data
         estimator.fit(X, y)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("booster", boosters)
     @pytest.mark.parametrize("tree_method", tree_methods)
@@ -234,8 +263,11 @@ class TestXGBoost:
 
         X, y, group = rank_data
         estimator.fit(X, y, group=group)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
 
 class TestCatboost:
@@ -290,8 +322,11 @@ class TestCatboost:
 
         X, y = cb_clf_data
         estimator.fit(X, y, cat_features=[0, 1])
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_regressor(self, catboost, cb_regr_data, trusted, boosting_type):
@@ -303,8 +338,11 @@ class TestCatboost:
 
         X, y = cb_regr_data
         estimator.fit(X, y, cat_features=[0, 1])
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)
 
     @pytest.mark.parametrize("boosting_type", boosting_types)
     def test_ranker(self, catboost, cb_rank_data, trusted, boosting_type):
@@ -316,5 +354,8 @@ class TestCatboost:
 
         X, y, group_id = cb_rank_data
         estimator.fit(X, y, cat_features=[0, 1], group_id=group_id)
-        loaded = loads(dumps(estimator), trusted=trusted)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
         assert_method_outputs_equal(estimator, loaded, X)
+
+        visualize(dumped, trusted=trusted)

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -269,3 +269,23 @@ class TestVisualizeTree:
         ]
         stdout, _ = capsys.readouterr()
         assert stdout.strip() == "\n".join(expected)
+
+    def test_long_bytes(self, capsys):
+        obj = {
+            "short_byte": b"abc",
+            "long_byte": b"010203040506070809101112131415",
+            "short_bytearray": bytearray(b"abc"),
+            "long_bytearray": bytearray(b"010203040506070809101112131415"),
+        }
+        dumped = sio.dumps(obj)
+        sio.visualize(dumped)
+
+        expected = [
+            "root: builtins.dict",
+            "├── short_byte: b'abc'",
+            "├── long_byte: b'01020304050...9101112131415'",
+            "├── short_bytearray: bytearray(b'abc')",
+            "└── long_bytearray: bytearray(b'01020304050...9101112131415')",
+        ]
+        stdout, _ = capsys.readouterr()
+        assert stdout.strip() == "\n".join(expected)


### PR DESCRIPTION
The `visualize` function failed when trying to visualize models that had byte attributes. This is because the node's children would contain raw bytes, which the function doesn't know how to visualize. Therefore, children of byte and byte array nodes are now skipped (in addition to the node types already being skipped).

To test this bug, I added a visualization test to the external packages like LightGBM, which make use of bytes. I'm not sure if some of the sklearn estimators could also be candidates, but it would surely be overkill to test visualizing all of them, whereas the overhead is not so big for the external packages.