### PR TITLE
FIX attempt at fixing broken GH workflow

### DIFF
--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,7 +1,6 @@
 name: Test performance and file size of skops persistence
 
 on:
-  pull_request:
   schedule:
     - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
   workflow_dispatch:

--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,6 +1,7 @@
 name: Test performance and file size of skops persistence
 
 on:
+  pull_request:
   schedule:
     - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
   workflow_dispatch:
@@ -18,13 +19,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.10"
     - name: Install requirements
       run: |
-        pip install .[tests]
+        pip install -e .[tests]
         pip --version
         pip list
     - name: Run persistence performance checks
-      run: python scripts/check_persistence_performance.py
+      run: python3.10 scripts/check_persistence_performance.py
     - name: Run file size checks
-      run: python scripts/check_file_size.py
+      run: python3.10 scripts/check_file_size.py


### PR DESCRIPTION
The GitHub action for testing the performance of persistence is broken since the [last](https://github.com/skops-dev/skops/actions/runs/4843527933/jobs/8631210678) [two](https://github.com/skops-dev/skops/actions/runs/4777497271/jobs/8493269141) weeks. The error is:

> ModuleNotFoundError: No module named 'skops.io'

This seems to be the same issue we already had previously with broken installs. Nothing relevant has been changed on the workflow yaml, so there is really no reason why it should suddenly break.

This PR attempts to fix the issue by making the following changes:

- Use Python 3.10 insteaad of 3.11
- Use pip install with `-e` flag
- Explicitly call `python3.10` instead of just `python`

A PR hook was added to trigger this workflow, it should be removed before merging.