### PR TITLE
FIX: Broken CI for MacOS and Python 3.8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,10 @@ jobs:
             sklearn_version: "1.2"
           - python: "3.11"
             sklearn_version: "nightly"
+        exclude:
+          # https://github.com/catboost/catboost/issues/2371
+          - os: "macos-latest"
+            python: "3.8"
 
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646


### PR DESCRIPTION
The job fails when trying to install catboost. The issue doesn't seem to be with catboost, though, but with how Python 3.8 detects the MacOS version inside GitHub runners.

If there is a better solution than just skipping, let me know.