### PR TITLE
MNT handle deprecation in publish action

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
       if: ${{ github.event.inputs.pypi_repo == 'testpypi' }}
 
     - name: Publish package to PyPI


### PR DESCRIPTION
We seem to need to change `repository_url` to `repository-url`

failed run: https://github.com/skops-dev/skops/actions/runs/5197942965

Message:
```
Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.
```
