### PR TITLE
MNT bump versions on the dev branch to 0.8

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,9 @@ skops Changelog
     :depth: 1
     :local:
 
+v0.8
+----
+
 
 v0.7
 ----

--- a/skops/__init__.py
+++ b/skops/__init__.py
@@ -16,7 +16,7 @@ import sys
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "0.7.dev0"
+__version__ = "0.8.dev0"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
Post release PR to move version on `main`.