### PR TITLE
MNT include all packages via find_packages

### DIFF
--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,6 +1,7 @@
 name: Test performance and file size of skops persistence
 
 on:
+  pull_request:
   schedule:
     - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
   workflow_dispatch:

--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,7 +1,6 @@
 name: Test performance and file size of skops persistence
 
 on:
-  pull_request:
   schedule:
     - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
   workflow_dispatch:

--- a/.github/workflows/persistence-performance.yml
+++ b/.github/workflows/persistence-performance.yml
@@ -1,6 +1,7 @@
 name: Test performance and file size of skops persistence
 
 on:
+  pull_request:
   schedule:
     - cron:  '0 9 * * 0'  # every sunday at 9:00 UTC
   workflow_dispatch:
@@ -21,7 +22,7 @@ jobs:
         python-version: "3.10"
     - name: Install requirements
       run: |
-        pip install -e .[tests]
+        pip install .[tests]
         pip --version
         pip list
     - name: Run persistence performance checks

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def setup_package():
             "rich": min_deps.tag_to_packages["rich"],
         },
         include_package_data=True,
-        packages=find_packages(),
+        packages=find_packages() + ["skops.io.old"],
     )
 
     setup(**package_data, **metadata)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # License: 3-clause BSD
 import builtins
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 # This is a bit (!) hackish: we are setting a global variable so that the
 # main modelcard __init__ can detect if it is being loaded by the setup
@@ -81,7 +81,7 @@ def setup_package():
             "rich": min_deps.tag_to_packages["rich"],
         },
         include_package_data=True,
-        packages=find_packages() + ["skops.io.old", "skops.io.tests"],
+        packages=find_namespace_packages(include=["skops*"]),
     )
 
     setup(**package_data, **metadata)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # License: 3-clause BSD
 import builtins
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 # This is a bit (!) hackish: we are setting a global variable so that the
 # main modelcard __init__ can detect if it is being loaded by the setup
@@ -80,7 +80,7 @@ def setup_package():
             "rich": min_deps.tag_to_packages["rich"],
         },
         include_package_data=True,
-        packages=["skops"],
+        packages=find_packages(),
     )
 
     setup(**package_data, **metadata)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def setup_package():
             "rich": min_deps.tag_to_packages["rich"],
         },
         include_package_data=True,
-        packages=find_packages() + ["skops.io.old"],
+        packages=find_packages() + ["skops.io.old", "skops.io.tests"],
     )
 
     setup(**package_data, **metadata)


### PR DESCRIPTION
we somehow forgot to include all packages in `packages` attribute. This adds them via `find_packages`.

We still get warnings for tests, but those we can fix later.