### PR TITLE
ENH add HTML repr in notebooks for Card

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ v0.8
 ----
 - Adds the abillity to set the :attr:`.Section.folded` property when using :meth:`.Card.add`.
   :pr:`361` by :user:`Thomas Lazarus <lazarust>`.
+- Add HTML representation of the :class:`skops.card.Card` instances in Jupyter
+  notebooks.
 
 v0.7
 ----

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,7 +14,7 @@ v0.8
 - Adds the abillity to set the :attr:`.Section.folded` property when using :meth:`.Card.add`.
   :pr:`361` by :user:`Thomas Lazarus <lazarust>`.
 - Add HTML representation of the :class:`skops.card.Card` instances in Jupyter
-  notebooks.
+  notebooks. :pr:`372` by `Adrin Jalali`_.
 
 v0.7
 ----

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -36,6 +36,8 @@ dependent_packages = {
     "catboost": ("1.0", "tests", "python_version < '3.11'"),
     "fairlearn": ("0.7.0", "docs, tests", None),
     "rich": ("12", "tests, rich", None),
+    # Required for the documentation build with sphinx-gallery
+    "markdown": ("3.4", "docs", None),
 }
 
 

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -16,7 +16,7 @@ from typing import Any, Iterator, Literal, Sequence, Union
 
 import joblib
 from huggingface_hub import ModelCardData
-from sklearn.utils import estimator_html_repr
+from sklearn.utils import available_if, estimator_html_repr
 from tabulate import tabulate  # type: ignore
 
 from skops.card._templates import CONTENT_PLACEHOLDER, SKOPS_TEMPLATE, Templates
@@ -1484,6 +1484,27 @@ class Card:
         markdown.
         """
         return self.render()
+
+    def _markdown_installed(self):
+        try:
+            import markdown  # type: ignore[import]  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @available_if(_markdown_installed)
+    def _repr_html_(self) -> str:
+        """Render the model card as HTML in a Jupyter Notebook.
+
+        This is only available if the user has `markdown` package installed.
+        This is only used in our documentation build, since sphinx-gallery
+        doesn't support `_repr_markdown_`. In a Jupyter notebook,
+        `_repr_markdown_` is used.
+        """
+        import markdown
+
+        return markdown.markdown(self.render())
 
     def _iterate_key_section_content(
         self,

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -1477,6 +1477,14 @@ class Card:
         """
         return "\n".join(self._generate_card())
 
+    def _repr_markdown_(self) -> str:
+        """Render the model card as markdown in a Jupyter Notebook.
+
+        Jupyter understands this method and if it exists, uses it to render the
+        markdown.
+        """
+        return self.render()
+
     def _iterate_key_section_content(
         self,
         data: dict[str, Section],

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -16,7 +16,8 @@ from typing import Any, Iterator, Literal, Sequence, Union
 
 import joblib
 from huggingface_hub import ModelCardData
-from sklearn.utils import available_if, estimator_html_repr
+from sklearn.utils import estimator_html_repr
+from sklearn.utils.metaestimators import available_if
 from tabulate import tabulate  # type: ignore
 
 from skops.card._templates import CONTENT_PLACEHOLDER, SKOPS_TEMPLATE, Templates


### PR DESCRIPTION
This makes for a nice visual in our examples and for people who use notebooks to work with the `Card` object.