### PR TITLE
Bump version to next dev version after release

### DIFF
--- a/skops/__init__.py
+++ b/skops/__init__.py
@@ -16,7 +16,7 @@ import sys
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "0.8.0"
+__version__ = "0.9.dev0"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
From `v0.8.0` to `0.9.dev0`.

@skops-dev/maintainers 