### PR TITLE
MNT: Support Catboost for Python 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,11 +28,6 @@ jobs:
             sklearn_version: "1.2"
           - python: "3.11"
             sklearn_version: "nightly"
-        exclude:
-          # https://github.com/catboost/catboost/issues/2371
-          - os: "macos-latest"
-            python: "3.8"
-
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 15

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -32,8 +32,7 @@ dependent_packages = {
     # required for persistence tests of external libraries
     "lightgbm": ("3", "tests", None),
     "xgboost": ("1.6", "tests", None),
-    # TODO: remove condition when catboost supports python 3.11
-    "catboost": ("1.0", "tests", "python_version < '3.11'"),
+    "catboost": ("1.0", "tests", None),
     "fairlearn": ("0.7.0", "docs, tests", None),
     "rich": ("12", "tests, rich", None),
 }


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #363 

Plus I have re-enable the tests on python 3.8 on MacOS. The catboost issue there is also solved. :)