### PR TITLE
ENH: Quantile Forest Support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ skops Changelog
 
 v0.9
 ----
+- Add support for `quantile-forest <https://github.com/zillow/quantile-forest>`__
+  estimators. :pr:`384` by :user:`Reid Johnson <reidjohnson>`.
 - Fix an issue with visualizing Skops files for `scikit-learn` tree estimators.
   :pr:`386` by :user:`Reid Johnson <reidjohnson>`.
 

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -15,6 +15,7 @@ dependent_packages = {
     "scikit-learn-intelex": ("2021.7.1", "docs", None),
     "huggingface_hub": ("0.10.1", "install", None),
     "tabulate": ("0.8.8", "install", None),
+    "quantile-forest": ("1.0.0", "install", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),
     "pytest-cov": ("2.9.0", "tests", None),
     "flake8": ("3.8.2", "tests", None),

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -15,7 +15,7 @@ dependent_packages = {
     "scikit-learn-intelex": ("2021.7.1", "docs", None),
     "huggingface_hub": ("0.10.1", "install", None),
     "tabulate": ("0.8.8", "install", None),
-    "quantile-forest": ("1.0.0", "install", None),
+    "quantile-forest": ("1.0.0", "tests", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),
     "pytest-cov": ("2.9.0", "tests", None),
     "flake8": ("3.8.2", "tests", None),

--- a/skops/io/_persist.py
+++ b/skops/io/_persist.py
@@ -15,7 +15,7 @@ from ._utils import LoadContext, SaveContext, _get_state, get_state
 # We load the dispatch functions from the corresponding modules and register
 # them. Old protocols are found in the 'old/' directory, with the protocol
 # version appended to the corresponding module name.
-modules = ["._general", "._numpy", "._scipy", "._sklearn"]
+modules = ["._general", "._numpy", "._scipy", "._sklearn", "._quantile_forest"]
 modules.extend([".old._general_v0", ".old._numpy_v0"])
 for module_name in modules:
     # register exposed functions for get_state and get_tree

--- a/skops/io/_quantile_forest.py
+++ b/skops/io/_quantile_forest.py
@@ -6,7 +6,7 @@ from quantile_forest._quantile_forest_fast import QuantileForest
 
 from ._protocol import PROTOCOL
 from ._sklearn import ReduceNode, reduce_get_state
-from ._utils import LoadContext, SaveContext, get_module
+from ._utils import LoadContext, SaveContext
 
 
 def quantile_forest_get_state(
@@ -31,10 +31,7 @@ class QuantileForestNode(ReduceNode):
             constructor=QuantileForest,
             trusted=trusted,
         )
-        self.trusted = self._get_trusted(
-            trusted,
-            [get_module(QuantileForest) + ".QuantileForest"],
-        )
+        self.trusted = self._get_trusted(trusted, [])
 
 
 # tuples of type and function that gets the state of that type

--- a/skops/io/_quantile_forest.py
+++ b/skops/io/_quantile_forest.py
@@ -6,44 +6,46 @@ from ._protocol import PROTOCOL
 from ._sklearn import ReduceNode, reduce_get_state
 from ._utils import LoadContext, SaveContext
 
-
-def _lazy_import():
-    from quantile_forest._quantile_forest_fast import QuantileForest
-
-    def quantile_forest_get_state(
-        obj: Any,
-        save_context: SaveContext,
-    ) -> dict[str, Any]:
-        state = reduce_get_state(obj, save_context)
-        state["__loader__"] = "QuantileForestNode"
-        return state
-
-    class QuantileForestNode(ReduceNode):
-        def __init__(
-            self,
-            state: dict[str, Any],
-            load_context: LoadContext,
-            trusted: bool | Sequence[str] = False,
-        ) -> None:
-            super().__init__(
-                state,
-                load_context,
-                constructor=QuantileForest,
-                trusted=trusted,
-            )
-            self.trusted = self._get_trusted(trusted, [])
-
-    return QuantileForest, QuantileForestNode, quantile_forest_get_state
-
-
 try:
-    QuantileForest, QuantileForestNode, quantile_forest_get_state = _lazy_import()
+    from quantile_forest._quantile_forest_fast import QuantileForest
+except ImportError:
+    QuantileForest = None
 
-    # tuples of type and function that gets the state of that type
+
+def quantile_forest_get_state(
+    obj: Any,
+    save_context: SaveContext,
+) -> dict[str, Any]:
+    state = reduce_get_state(obj, save_context)
+    state["__loader__"] = "QuantileForestNode"
+    return state
+
+
+class QuantileForestNode(ReduceNode):
+    def __init__(
+        self,
+        state: dict[str, Any],
+        load_context: LoadContext,
+        trusted: bool | Sequence[str] = False,
+    ) -> None:
+        if QuantileForest is None:
+            raise ImportError(
+                "`quantile_forest` is missing and needs to be installed in order to"
+                " load this model."
+            )
+
+        super().__init__(
+            state,
+            load_context,
+            constructor=QuantileForest,
+            trusted=trusted,
+        )
+        self.trusted = self._get_trusted(trusted, [])
+
+
+# tuples of type and function that gets the state of that type
+if QuantileForest is not None:
     GET_STATE_DISPATCH_FUNCTIONS = [(QuantileForest, quantile_forest_get_state)]
 
-    # tuples of type and function that creates the instance of that type
-    NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}
-except ModuleNotFoundError:
-    GET_STATE_DISPATCH_FUNCTIONS = []
-    NODE_TYPE_MAPPING = {}
+# tuples of type and function that creates the instance of that type
+NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}

--- a/skops/io/_quantile_forest.py
+++ b/skops/io/_quantile_forest.py
@@ -2,40 +2,48 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
-from quantile_forest._quantile_forest_fast import QuantileForest
-
 from ._protocol import PROTOCOL
 from ._sklearn import ReduceNode, reduce_get_state
 from ._utils import LoadContext, SaveContext
 
 
-def quantile_forest_get_state(
-    obj: Any,
-    save_context: SaveContext,
-) -> dict[str, Any]:
-    state = reduce_get_state(obj, save_context)
-    state["__loader__"] = "QuantileForestNode"
-    return state
+def _lazy_import():
+    from quantile_forest._quantile_forest_fast import QuantileForest
+
+    def quantile_forest_get_state(
+        obj: Any,
+        save_context: SaveContext,
+    ) -> dict[str, Any]:
+        state = reduce_get_state(obj, save_context)
+        state["__loader__"] = "QuantileForestNode"
+        return state
+
+    class QuantileForestNode(ReduceNode):
+        def __init__(
+            self,
+            state: dict[str, Any],
+            load_context: LoadContext,
+            trusted: bool | Sequence[str] = False,
+        ) -> None:
+            super().__init__(
+                state,
+                load_context,
+                constructor=QuantileForest,
+                trusted=trusted,
+            )
+            self.trusted = self._get_trusted(trusted, [])
+
+    return QuantileForest, QuantileForestNode, quantile_forest_get_state
 
 
-class QuantileForestNode(ReduceNode):
-    def __init__(
-        self,
-        state: dict[str, Any],
-        load_context: LoadContext,
-        trusted: bool | Sequence[str] = False,
-    ) -> None:
-        super().__init__(
-            state,
-            load_context,
-            constructor=QuantileForest,
-            trusted=trusted,
-        )
-        self.trusted = self._get_trusted(trusted, [])
+try:
+    QuantileForest, QuantileForestNode, quantile_forest_get_state = _lazy_import()
 
+    # tuples of type and function that gets the state of that type
+    GET_STATE_DISPATCH_FUNCTIONS = [(QuantileForest, quantile_forest_get_state)]
 
-# tuples of type and function that gets the state of that type
-GET_STATE_DISPATCH_FUNCTIONS = [(QuantileForest, quantile_forest_get_state)]
-
-# tuples of type and function that creates the instance of that type
-NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}
+    # tuples of type and function that creates the instance of that type
+    NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}
+except ModuleNotFoundError:
+    GET_STATE_DISPATCH_FUNCTIONS = []
+    NODE_TYPE_MAPPING = {}

--- a/skops/io/_quantile_forest.py
+++ b/skops/io/_quantile_forest.py
@@ -5,15 +5,14 @@ from typing import Any, Sequence
 from quantile_forest._quantile_forest_fast import QuantileForest
 
 from ._protocol import PROTOCOL
-
-from ._sklearn import reduce_get_state, ReduceNode
+from ._sklearn import ReduceNode, reduce_get_state
 from ._utils import LoadContext, SaveContext, get_module
 
 
 def quantile_forest_get_state(
-        obj: Any,
-        save_context: SaveContext,
-    ) -> dict[str, Any]:
+    obj: Any,
+    save_context: SaveContext,
+) -> dict[str, Any]:
     state = reduce_get_state(obj, save_context)
     state["__loader__"] = "QuantileForestNode"
     return state
@@ -39,9 +38,7 @@ class QuantileForestNode(ReduceNode):
 
 
 # tuples of type and function that gets the state of that type
-GET_STATE_DISPATCH_FUNCTIONS = [
-    (QuantileForest, quantile_forest_get_state)
-]
+GET_STATE_DISPATCH_FUNCTIONS = [(QuantileForest, quantile_forest_get_state)]
 
 # tuples of type and function that creates the instance of that type
 NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}

--- a/skops/io/_quantile_forest.py
+++ b/skops/io/_quantile_forest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from quantile_forest._quantile_forest_fast import QuantileForest
+
+from ._protocol import PROTOCOL
+
+from ._sklearn import reduce_get_state, ReduceNode
+from ._utils import LoadContext, SaveContext, get_module
+
+
+def quantile_forest_get_state(
+        obj: Any,
+        save_context: SaveContext,
+    ) -> dict[str, Any]:
+    state = reduce_get_state(obj, save_context)
+    state["__loader__"] = "QuantileForestNode"
+    return state
+
+
+class QuantileForestNode(ReduceNode):
+    def __init__(
+        self,
+        state: dict[str, Any],
+        load_context: LoadContext,
+        trusted: bool | Sequence[str] = False,
+    ) -> None:
+        super().__init__(
+            state,
+            load_context,
+            constructor=QuantileForest,
+            trusted=trusted,
+        )
+        self.trusted = self._get_trusted(
+            trusted,
+            [get_module(QuantileForest) + ".QuantileForest"],
+        )
+
+
+# tuples of type and function that gets the state of that type
+GET_STATE_DISPATCH_FUNCTIONS = [
+    (QuantileForest, quantile_forest_get_state)
+]
+
+# tuples of type and function that creates the instance of that type
+NODE_TYPE_MAPPING = {("QuantileForestNode", PROTOCOL): QuantileForestNode}

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -232,9 +232,6 @@ def walk_tree(
             "here: https://github.com/skops-dev/skops/issues"
         )
 
-    if node_name == "constructor":
-        return
-
     if isinstance(node, dict):
         num_nodes = len(node)
         for i, (key, val) in enumerate(node.items(), start=1):

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -232,6 +232,9 @@ def walk_tree(
             "here: https://github.com/skops-dev/skops/issues"
         )
 
+    if node_name == "constructor":
+        return
+
     if isinstance(node, dict):
         num_nodes = len(node)
         for i, (key, val) in enumerate(node.items(), start=1):

--- a/skops/io/tests/test_external.py
+++ b/skops/io/tests/test_external.py
@@ -408,21 +408,22 @@ class TestQuantileForest:
             "quantile_forest._quantile_forest_fast.QuantileForest",
         ]
 
-    def test_quantile_forest(self, quantile_forest, regr_data, trusted):
-        tree_methods = [
-            quantile_forest.RandomForestQuantileRegressor,
-            quantile_forest.ExtraTreesQuantileRegressor,
-        ]
+    tree_methods = [
+        "RandomForestQuantileRegressor",
+        "ExtraTreesQuantileRegressor",
+    ]
 
-        for tree_method in tree_methods:
-            estimator = tree_method()
-            loaded = loads(dumps(estimator), trusted=trusted)
-            assert_params_equal(estimator.get_params(), loaded.get_params())
+    @pytest.mark.parametrize("tree_method", tree_methods)
+    def test_quantile_forest(self, quantile_forest, regr_data, trusted, tree_method):
+        cls = getattr(quantile_forest, tree_method)
+        estimator = cls()
+        loaded = loads(dumps(estimator), trusted=trusted)
+        assert_params_equal(estimator.get_params(), loaded.get_params())
 
-            X, y = regr_data
-            estimator.fit(X, y)
-            dumped = dumps(estimator)
-            loaded = loads(dumped, trusted=trusted)
-            assert_method_outputs_equal(estimator, loaded, X)
+        X, y = regr_data
+        estimator.fit(X, y)
+        dumped = dumps(estimator)
+        loaded = loads(dumped, trusted=trusted)
+        assert_method_outputs_equal(estimator, loaded, X)
 
-            visualize(dumped, trusted=trusted)
+        visualize(dumped, trusted=trusted)


### PR DESCRIPTION
Fixes #383.

The [quantile-forest](https://github.com/zillow/quantile-forest) package extends sklearn random forest regressors to implement quantile regression forests. Without these changes, the Cython-based model object is unable to be loaded by skops due to its use of the `__reduce__` method.

I understand adding support for another package may be outside the current scope of this project. As the primary maintainer of the quantile-forest package, I'd also be interested in better understanding if there's a recommended alternative to the use of `__reduce__` that would enable the model to be compatible with this project's existing secure persistence feature.