### PR TITLE
FIX: Decision Tree Visualization

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ skops Changelog
 
 v0.9
 ----
+- Fix an issue with visualizing Skops files for `scikit-learn` tree estimators.
+  :pr:`386` by :user:`Reid Johnson <reidjohnson>`.
 
 v0.8
 ----

--- a/skops/io/_sklearn.py
+++ b/skops/io/_sklearn.py
@@ -108,7 +108,7 @@ class ReduceNode(Node):
             "constructor": TypeNode(
                 {
                     "__class__": constructor.__name__,
-                    "__module__": constructor.__module__,
+                    "__module__": get_module(constructor),
                     "__id__": id(constructor),
                 },
                 load_context,

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -232,7 +232,15 @@ def walk_tree(
             "here: https://github.com/skops-dev/skops/issues"
         )
 
-    if node_name == "constructor":
+    if isinstance(node, type):
+        yield NodeInfo(
+            level=level,
+            key=node_name,
+            val=type(node).__name__,
+            is_self_safe=False,
+            is_safe=False,
+            is_last=is_last,
+        )
         return
 
     if isinstance(node, dict):

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -182,7 +182,8 @@ def walk_tree(
     node_name: str = "root",
     level: int = 0,
     is_last: bool = False,
-    **kwargs,
+    is_self_safe: bool = False,
+    is_safe: bool = False,
 ) -> Iterator[NodeInfo]:
     """Visit all nodes of the tree and yield their important attributes.
 
@@ -203,9 +204,6 @@ def walk_tree(
     node: :class:`skops.io._audit.Node`
         The current node to visit. Children are visited recursively.
 
-    show: "all" or "untrusted" or "trusted"
-        Whether to print all nodes, only untrusted nodes, or only trusted nodes.
-
     node_name: str (default="root")
         The key to the current node. If "key_types" is encountered, it is
         skipped.
@@ -216,17 +214,18 @@ def walk_tree(
     is_last: bool (default=False)
         Whether this is the last node among its sibling nodes.
 
+    is_self_safe: bool (default=False)
+        Whether this specific node is safe.
+
+    is_safe: bool (default=False)
+        Whether this node and all of its children are safe.
+
     Yields
     ------
     :class:`~NodeInfo`:
         A dataclass containing the aforementioned information.
 
     """
-    if "is_self_safe" in kwargs:
-        is_self_safe = kwargs["is_self_safe"]
-    if "is_safe" in kwargs:
-        is_safe = kwargs["is_safe"]
-
     # key_types is not helpful, as it is artificially added by skops to
     # circumvent the fact that json only allows keys to be strings. It is not
     # useful to the user and adds a lot of noise, thus skip key_types.

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -11,7 +11,7 @@ from ._audit import VALID_NODE_CHILD_TYPES, Node, get_tree
 from ._general import BytearrayNode, BytesNode, FunctionNode, JsonNode, ListNode
 from ._numpy import NdArrayNode
 from ._scipy import SparseMatrixNode
-from ._utils import LoadContext, get_module
+from ._utils import LoadContext
 
 # The children of these types are not visualized
 SKIPPED_TYPES = (
@@ -182,8 +182,6 @@ def walk_tree(
     node_name: str = "root",
     level: int = 0,
     is_last: bool = False,
-    is_self_safe: bool = False,
-    is_safe: bool = False,
 ) -> Iterator[NodeInfo]:
     """Visit all nodes of the tree and yield their important attributes.
 
@@ -214,12 +212,6 @@ def walk_tree(
     is_last: bool (default=False)
         Whether this is the last node among its sibling nodes.
 
-    is_self_safe: bool (default=False)
-        Whether this specific node is safe.
-
-    is_safe: bool (default=False)
-        Whether this node and all of its children are safe.
-
     Yields
     ------
     :class:`~NodeInfo`:
@@ -237,17 +229,6 @@ def walk_tree(
             "here: https://github.com/skops-dev/skops/issues"
         )
 
-    if type(node) is type:
-        yield NodeInfo(
-            level=level,
-            key=node_name,
-            val=get_module(node) + "." + node.__name__,
-            is_self_safe=is_self_safe,
-            is_safe=is_safe,
-            is_last=is_last,
-        )
-        return
-
     if isinstance(node, dict):
         num_nodes = len(node)
         for i, (key, val) in enumerate(node.items(), start=1):
@@ -256,8 +237,6 @@ def walk_tree(
                 node_name=key,
                 level=level,
                 is_last=i == num_nodes,
-                is_self_safe=is_self_safe,
-                is_safe=is_safe,
             )
         return
 
@@ -304,8 +283,6 @@ def walk_tree(
         node.children,
         node_name=node_name,
         level=level + 1,
-        is_self_safe=node.is_self_safe(),
-        is_safe=node.is_safe(),
     )
 
 

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -232,6 +232,9 @@ def walk_tree(
             "here: https://github.com/skops-dev/skops/issues"
         )
 
+    if node_name == "constructor":
+        return
+
     if isinstance(node, dict):
         num_nodes = len(node)
         for i, (key, val) in enumerate(node.items(), start=1):

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -290,20 +290,20 @@ class TestVisualizeTree:
         dumped = sio.dumps(model)
         sio.visualize(dumped)
 
-        classes = []
         if isinstance(model, DecisionTreeClassifier):
-            criterion = "gini"
-            classes = [
+            dt_criterion = "gini"
+            dt_classes = [
                 "    ├── classes_: numpy.ndarray",
                 "    ├── n_classes_: numpy.int64",
             ]
         elif isinstance(model, DecisionTreeRegressor):
-            criterion = "squared_error"
+            dt_criterion = "squared_error"
+            dt_classes = []
 
         expected = [
             "root: sklearn.tree._classes.{}".format(cls.__name__),
             "└── attrs: builtins.dict",
-            '    ├── criterion: json-type("{}")'.format(criterion),
+            '    ├── criterion: json-type("{}")'.format(dt_criterion),
             '    ├── splitter: json-type("best")',
             "    ├── max_depth: json-type(null)",
             "    ├── min_samples_split: json-type(2)",
@@ -318,7 +318,7 @@ class TestVisualizeTree:
             "    ├── n_features_in_: json-type(2)",
             "    ├── n_outputs_: json-type(1)",
         ]
-        expected += classes
+        expected += dt_classes
         expected += [
             "    ├── max_features_: json-type(2)",
             "    ├── tree_: sklearn.tree._tree.Tree",

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -331,7 +331,7 @@ class TestVisualizeTree:
             "    │   │   ├── content: json-type(2)",
             "    │   │   ├── content: numpy.ndarray",
             "    │   │   └── content: json-type(1)",
-            "    │   └── constructor: type [UNSAFE]",
+            "    │   └── constructor: sklearn.tree._tree.Tree",
             '    └── _sklearn_version: json-type("{}")'.format(sklearn.__version__),
         ]
         stdout, _ = capsys.readouterr()

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -40,7 +40,7 @@ class TestVisualizeTree:
                     ("scale", MinMaxScaler()),
                 ])),
             ])),
-            ("clf", LogisticRegression(random_state=0, solver="lbfgs")),
+            ("clf", LogisticRegression(random_state=0, solver="liblinear")),
         ]).fit([[0, 1], [2, 3], [4, 5]], [0, 1, 2])
         # fmt: on
         return pipeline

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import sklearn
-from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import (
     FunctionTransformer,
@@ -39,7 +39,7 @@ class TestVisualizeTree:
                     ("scale", MinMaxScaler()),
                 ])),
             ])),
-            ("clf", LogisticRegression(random_state=0, solver="liblinear")),
+            ("clf", RandomForestRegressor(random_state=0)),
         ]).fit([[0, 1], [2, 3], [4, 5]], [0, 1, 2])
         # fmt: on
         return pipeline

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -13,6 +13,7 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.utils import parse_version
 
 import skops.io as sio
 
@@ -315,6 +316,10 @@ class TestVisualizeTree:
             "    ├── min_impurity_decrease: json-type(0.0)",
             "    ├── class_weight: json-type(null)",
             "    ├── ccp_alpha: json-type(0.0)",
+        ]
+        if parse_version(sklearn.__version__) >= parse_version("1.4.0dev"):
+            expected += ["    ├── monotonic_cst: json-type(null)"]
+        expected += [
             "    ├── n_features_in_: json-type(2)",
             "    ├── n_outputs_: json-type(1)",
         ]


### PR DESCRIPTION
Fixes issue  #385.

The root cause of the bug appears to be that the base sklearn tree constructor object is not wrapped as a valid skops `Node` type, but is still included in the visualized object tree.

This PR fixes the issue by appropriately processing this node.