### PR TITLE
MNT: updates to HF Hub, manage fairlearn deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ filterwarnings = [
     # https://github.com/scikit-learn/scikit-learn/pull/23633
     "ignore:Unlike other reduction functions:FutureWarning",
     # https://github.com/scikit-learn/scikit-learn/pull/25157
-    "ignore:\\w+ is deprecated. Use files\\(\\) instead:DeprecationWarning"
+    "ignore:\\w+ is deprecated. Use files\\(\\) instead:DeprecationWarning",
+    # comes from fairlearn
+    "ignore:DataFrame.applymap has been deprecated. Use DataFrame.map instead:FutureWarning",
 ]
 markers = [
     "network: marks tests as requiring internet (deselect with '-m \"not network\"')",

--- a/skops/_min_dependencies.py
+++ b/skops/_min_dependencies.py
@@ -13,7 +13,7 @@ PYTEST_MIN_VERSION = "5.0.1"
 dependent_packages = {
     "scikit-learn": ("0.24", "install", None),
     "scikit-learn-intelex": ("2021.7.1", "docs", None),
-    "huggingface_hub": ("0.10.1", "install", None),
+    "huggingface_hub": ("0.18.0.rc0", "install", None),
     "tabulate": ("0.8.8", "install", None),
     "quantile-forest": ("1.0.0", "tests", None),
     "pytest": (PYTEST_MIN_VERSION, "tests", None),

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -114,7 +114,7 @@ def metadata_from_config(config_path: Union[str, Path]) -> ModelCardData:
     # https://huggingface.co/docs/hub/models-widgets-examples
     if example_input:
         if "tabular" in task:
-            card_data.widget = {"structuredData": example_input}  # type: ignore
+            card_data.widget = [{"structuredData": example_input}]  # type: ignore
         # TODO: add text data example here.
 
     return card_data
@@ -1396,7 +1396,7 @@ class Card:
         metadata_reprs = []
         for key, val in self.metadata.to_dict().items() if self.metadata else {}:
             if key == "widget":
-                metadata_reprs.append("metadata.widget={...},")
+                metadata_reprs.append("metadata.widget=[{...}],")
                 continue
 
             metadata_reprs.append(self._format_repr(f"metadata.{key}={val},"))

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -1186,14 +1186,16 @@ class TestMetadata:
         metadata = metadata_load(local_path=Path(destination_path) / "README.md")
         assert "widget" in metadata
 
-        expected_data = {
-            "structuredData": {
-                "petal length (cm)": [1.4, 1.4, 1.3],
-                "petal width (cm)": [0.2, 0.2, 0.2],
-                "sepal length (cm)": [5.1, 4.9, 4.7],
-                "sepal width (cm)": [3.5, 3.0, 3.2],
-            }
-        }
+        expected_data = [
+            {
+                "structuredData": {
+                    "petal length (cm)": [1.4, 1.4, 1.3],
+                    "petal width (cm)": [0.2, 0.2, 0.2],
+                    "sepal length (cm)": [5.1, 4.9, 4.7],
+                    "sepal width (cm)": [3.5, 3.0, 3.2],
+                }
+            },
+        ]
         assert metadata["widget"] == expected_data
 
         for tag in ["sklearn", "skops", "tabular-classification"]:
@@ -1403,7 +1405,7 @@ class TestCardRepr:
             library_name="sklearn",
             tags=["sklearn", "tabular-classification"],
             foo={"bar": 123},
-            widget={"something": "very-long"},
+            widget=[{"something": "very-long"}],
         )
         card.metadata = metadata
 
@@ -1414,7 +1416,7 @@ class TestCardRepr:
             "  metadata.library_name=sklearn,",
             "  metadata.tags=['sklearn', 'tabular-classification'],",
             "  metadata.foo={'bar': 123},",
-            "  metadata.widget={...},",
+            "  metadata.widget=[{...}],",
         ]
         expected = "\n".join(expected_lines[:2] + extra_lines + expected_lines[2:])
 

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, List, Literal, MutableMapping, Optional, Sequence, Union
 
 import numpy as np
-from huggingface_hub import HfApi, InferenceApi, snapshot_download
+from huggingface_hub import HfApi, InferenceClient, snapshot_download
 from sklearn.utils import check_array
 
 SUPPORTED_TASKS = [
@@ -755,9 +755,9 @@ def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> An
         inputs = {f"x{i}": data[:, i] for i in range(data.shape[1])}
         inputs = {"data": inputs}
 
-    res = InferenceApi(repo_id=repo_id, task=model_info.pipeline_tag, token=token)(
-        inputs=inputs
-    )
+    client = InferenceClient(token=token)
+    res_bytes = client.post(json={"inputs": inputs}, model=repo_id)
+    res = json.loads(res_bytes.decode("utf-8"))
 
     if isinstance(res, list):
         return np.array(res)


### PR DESCRIPTION
Some maintenance work to make skops future proof:

1. Ignore `FutureWarning` stemming from fairlearn: New pandas versions give `FutureWarning` for applymap. We have to wait for fairlearn to update this.
2. Make the widget attribute an array: Starting from HF Hub 0.18, it has to be an array.
3. InferenceApi is deprecated move to InferenceClient: API changed a little bit, had to be adjusted.

Note: DON'T MERGE THIS YET. The min version of HF Hub has been increased to 0.18 to test the changes but it actually should be lowered to 0.17 once CI is green for 0.18.