### PR TITLE
DEPR deprecate hub_utils.get_model_output

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,7 +17,7 @@ v0.9
 - Fix an issue with visualizing Skops files for `scikit-learn` tree estimators.
   :pr:`386` by :user:`Reid Johnson <reidjohnson>`.
 - :func:`skops.hug_utils.get_model_output` is deprecated and will be removed in version
-  0.10.
+  0.10. :pr:`396` by `Adrin Jalali`_.
 
 v0.8
 ----

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ v0.9
   estimators. :pr:`384` by :user:`Reid Johnson <reidjohnson>`.
 - Fix an issue with visualizing Skops files for `scikit-learn` tree estimators.
   :pr:`386` by :user:`Reid Johnson <reidjohnson>`.
+- :func:`skops.hug_utils.get_model_output` is deprecated and will be removed in version
+  0.10.
 
 v0.8
 ----

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -744,11 +744,9 @@ def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> An
     available.
     """
     warnings.warn(
-        (
-            "This feature is no longer free on hf.co and therefore this function will"
-            " be removed in the next release. Use `huggingface_hub.InferenceClient`"
-            " instead."
-        ),
+        "This feature is no longer free on hf.co and therefore this function will"
+        " be removed in the next release. Use `huggingface_hub.InferenceClient`"
+        " instead.",
         FutureWarning,
     )
     model_info = HfApi().model_info(repo_id=repo_id, use_auth_token=token)  # type: ignore

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -744,9 +744,12 @@ def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> An
     available.
     """
     warnings.warn(
-        "This feature is no longer free on hf.co and therefore this function will"
-        " be removed in the next release. Use `huggingface_hub.InferenceClient`"
-        " instead."
+        (
+            "This feature is no longer free on hf.co and therefore this function will"
+            " be removed in the next release. Use `huggingface_hub.InferenceClient`"
+            " instead."
+        ),
+        FutureWarning,
     )
     model_info = HfApi().model_info(repo_id=repo_id, use_auth_token=token)  # type: ignore
     if not model_info.pipeline_tag:

--- a/skops/hub_utils/_hf_hub.py
+++ b/skops/hub_utils/_hf_hub.py
@@ -9,6 +9,7 @@ import itertools
 import json
 import os
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any, List, Literal, MutableMapping, Optional, Sequence, Union
 
@@ -702,10 +703,15 @@ def download(
         shutil.rmtree(path=cached_folder)
 
 
+# TODO(v0.10): remove this function
 def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> Any:
     """Returns the output of the model using Hugging Face Hub's inference API.
 
     See the :ref:`User Guide <hf_hub_inference>` for more details.
+
+    .. deprecated:: 0.9
+        Will be removed in version 0.10. Use ``huggingface_hub.InferenceClient``
+        instead.
 
     Parameters
     ----------
@@ -737,8 +743,11 @@ def get_model_output(repo_id: str, data: Any, token: Optional[str] = None) -> An
     Also note that if the model repo is private, the inference API would not be
     available.
     """
-    # TODO: the "type: ignore" should eventually become unncessary when hf_hub
-    # is updated
+    warnings.warn(
+        "This feature is no longer free on hf.co and therefore this function will"
+        " be removed in the next release. Use `huggingface_hub.InferenceClient`"
+        " instead."
+    )
     model_info = HfApi().model_info(repo_id=repo_id, use_auth_token=token)  # type: ignore
     if not model_info.pipeline_tag:
         raise ValueError(

--- a/skops/hub_utils/tests/test_hf_hub.py
+++ b/skops/hub_utils/tests/test_hf_hub.py
@@ -503,13 +503,20 @@ def test_inference(
 
     X_test = data.data.head(5)
     y_pred = model.predict(X_test)
-    output = get_model_output(repo_id, data=X_test, token=HF_HUB_TOKEN)
+    with pytest.warns(FutureWarning):
+        output = get_model_output(repo_id, data=X_test, token=HF_HUB_TOKEN)
 
     # cleanup
     client.delete_repo(repo_id=repo_id, token=HF_HUB_TOKEN)
     model_path.unlink(missing_ok=True)
 
     assert np.allclose(output, y_pred)
+
+
+def test_get_model_output_deprecated():
+    with pytest.raises(Exception):
+        with pytest.warns(FutureWarning, match="This feature is no longer free"):
+            get_model_output("dummy", data=iris.data)
 
 
 def test_get_config(repo_path, config_json):


### PR DESCRIPTION
This deprecates the function, to be removed in the next released.