### PR TITLE
MNT update linters and use ruff

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[docs,tests]
-        pip install black=="22.6.0" isort=="5.10.1" mypy=="1.0.0"
+        pip install black=="23.9.1" ruff=="0.0.292" mypy=="1.0.0"
         pip uninstall --yes scikit-learn
         if [ ${{ matrix.sklearn_version }} == "nightly" ];
           then pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scikit-learn;
@@ -73,7 +73,7 @@ jobs:
       run: black --check --diff .
 
     - name: Check isort
-      run: isort --check --diff .
+      run: ruff --check --diff .
 
     - name: Tests
       env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,7 +73,7 @@ jobs:
       run: black --check --diff .
 
     - name: Check isort
-      run: ruff --check --diff .
+      run: ruff check --diff .
 
     - name: Tests
       env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Check black
       run: black --check --diff .
 
-    - name: Check isort
+    - name: Check ruff
       run: ruff check --diff .
 
     - name: Tests

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[docs,tests]
-        pip install black=="23.9.1" ruff=="0.0.292" mypy=="1.0.0"
+        pip install black=="23.9.1" ruff=="0.0.292" mypy=="1.6.0"
         pip uninstall --yes scikit-learn
         if [ ${{ matrix.sklearn_version }} == "nightly" ];
           then pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scikit-learn;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: ruff
         args: ["--fix", "--show-source"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.6.0
     hooks:
     -   id: mypy
         args: [--config-file=pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,15 @@ repos:
     -   id: check-case-conflict
     -   id: check-merge-conflict
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.9.1
     hooks:
     -   id: black
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.292
     hooks:
-    -   id: flake8
-        types: [file, python]
--   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
+    -   id: ruff
+        args: ["--fix", "--show-source"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
     hooks:

--- a/examples/plot_custom_model_card.py
+++ b/examples/plot_custom_model_card.py
@@ -163,7 +163,9 @@ _, plot_file_name = mkstemp(prefix="skops-", suffix=".png")
 display.figure_.savefig(plot_file_name)
 model_card.add_plot(
     **{
-        "Regression on California Housing dataset/Results/Partial Dependence Plots": plot_file_name
+        "Regression on California Housing dataset/Results/Partial Dependence Plots": (
+            plot_file_name
+        )
     },
 )
 

--- a/examples/plot_tabular_regression.py
+++ b/examples/plot_tabular_regression.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from tempfile import mkdtemp, mkstemp
 
 import matplotlib.pyplot as plt
-import pandas as pd
 import sklearn
 from sklearn.datasets import load_diabetes
 from sklearn.linear_model import LinearRegression
@@ -42,7 +41,8 @@ X_train, X_test, y_train, y_test = train_test_split(
 # Train a Model
 # =============
 # To train a model, we need to convert our data first to vectors. We will use
-# StandardScalar in our pipeline. We will fit a Linear Regression model with the outputs of the scalar.
+# StandardScalar in our pipeline. We will fit a Linear Regression model with
+# the outputs of the scalar.
 model = Pipeline(
     [
         ("scaler", StandardScaler()),
@@ -112,13 +112,14 @@ model_description = (
 model_card_authors = "skops_user, lazarust"
 citation_bibtex = "bibtex\n@inproceedings{...,year={2022}}"
 model_card.add(
+    folded=False,
     **{
         "Model Card Authors": model_card_authors,
         "Intended uses & limitations": limitations,
         "Citation": citation_bibtex,
         "Model description": model_description,
         "Model description/Intended uses & limitations": limitations,
-    }
+    },
 )
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ line-length = 88
 target_version = ['py38', 'py39', 'py310', 'py311']
 preview = true
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+# all rules can be found here: https://beta.ruff.rs/docs/rules/
+select = ["E", "F", "W", "I"]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -1254,8 +1254,9 @@ class Card:
         description: str | None = None,
     ) -> Self:
         """
-        Add a :class:`fairlearn.metrics.MetricFrame` table to the model card. The table contains
-        the difference, group_ma, group_min, and ratio for each metric.
+        Add a :class:`fairlearn.metrics.MetricFrame` table to the model card.
+        The table contains the difference, group_ma, group_min, and ratio for
+        each metric.
 
         Parameters
         ----------
@@ -1451,9 +1452,10 @@ class Card:
             Filepath to save your card.
 
         plot_path: str
-            Filepath to save the plots. Use this when saving the model card before creating the
-            repository. Without this path the README will have an absolute path to the plot that
-            won't exist in the repository.
+            Filepath to save the plots. Use this when saving the model card
+            before creating the repository. Without this path the README will
+            have an absolute path to the plot that won't exist in the
+            repository.
 
         Notes
         -----
@@ -1487,7 +1489,8 @@ class Card:
         Parameters
         ----------
         data : dict[str, Section]
-            The card data to iterate through. This is usually the sections and subsections.
+            The card data to iterate through. This is usually the sections and
+            subsections.
 
         level : int, optional
             The level of the section, by default 0. This keeps track of subsections.

--- a/skops/card/_templates.py
+++ b/skops/card/_templates.py
@@ -67,8 +67,10 @@ _HUB_TEMPLATE = {
     "Model Details/Model Description/Model type": CONTENT_PLACEHOLDER,
     "Model Details/Model Description/Language(s) (NLP)": CONTENT_PLACEHOLDER,
     "Model Details/Model Description/License": CONTENT_PLACEHOLDER,
-    "Model Details/Model Description/Finetuned from model [optional]": CONTENT_PLACEHOLDER,
-    "Model Details/Model Description/Resources for more information": CONTENT_PLACEHOLDER,
+    "Model Details/Model Description/Finetuned from model [optional]":
+        CONTENT_PLACEHOLDER,
+    "Model Details/Model Description/Resources for more information":
+        CONTENT_PLACEHOLDER,
 
     "Uses": "",
     # Address questions around how the model is intended to be used, including
@@ -102,8 +104,10 @@ _HUB_TEMPLATE = {
     "Training Details/Training Procedure [optional]": "",
     # This relates heavily to the Technical Specifications. Content here should
     # link to that section when it is relevant to the training procedure.
-    "Training Details/Training Procedure [optional]/Preprocessing": CONTENT_PLACEHOLDER,
-    "Training Details/Training Procedure [optional]/Speeds, Sizes, Times": CONTENT_PLACEHOLDER,
+    "Training Details/Training Procedure [optional]/Preprocessing":
+        CONTENT_PLACEHOLDER,
+    "Training Details/Training Procedure [optional]/Speeds, Sizes, Times":
+        CONTENT_PLACEHOLDER,
     # This section provides information about throughput, start/end time,
     # checkpoint size if relevant, etc.
 
@@ -137,10 +141,14 @@ _HUB_TEMPLATE = {
     "Environmental Impact/Carbon Emitted": CONTENT_PLACEHOLDER,
 
     "Technical Specifications [optional]": "",
-    "Technical Specifications [optional]/Model Architecture and Objective": CONTENT_PLACEHOLDER,
-    "Technical Specifications [optional]/Compute Infrastructure": CONTENT_PLACEHOLDER,
-    "Technical Specifications [optional]/Compute Infrastructure/Hardware": CONTENT_PLACEHOLDER,
-    "Technical Specifications [optional]/Compute Infrastructure/Software": CONTENT_PLACEHOLDER,
+    "Technical Specifications [optional]/Model Architecture and Objective":
+        CONTENT_PLACEHOLDER,
+    "Technical Specifications [optional]/Compute Infrastructure":
+        CONTENT_PLACEHOLDER,
+    "Technical Specifications [optional]/Compute Infrastructure/Hardware":
+        CONTENT_PLACEHOLDER,
+    "Technical Specifications [optional]/Compute Infrastructure/Software":
+        CONTENT_PLACEHOLDER,
 
     "Citation [optional]": "",
     # If there is a paper or blog post introducing the model, the APA and Bibtex
@@ -155,7 +163,8 @@ _HUB_TEMPLATE = {
     "More Information [optional]": CONTENT_PLACEHOLDER,
     "Model Card Authors [optional]": CONTENT_PLACEHOLDER,
     "Model Card Contact": CONTENT_PLACEHOLDER,
-    "How to Get Started with the Model": f"""Use the code below to get started with the model.
+    "How to Get Started with the Model":
+        f"""Use the code below to get started with the model.
 
 <details>
 <summary> Click to expand </summary>

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -807,14 +807,12 @@ class TestRender:
         model_card.metadata.foo = "something"
         model_card.metadata.bar = "something else"
         rendered = model_card.render()
-        expected = textwrap.dedent(
-            """
+        expected = textwrap.dedent("""
             ---
             foo: something
             bar: something else
             ---
-            """
-        ).strip()
+            """).strip()
         assert rendered.startswith(expected)
 
 
@@ -1362,13 +1360,11 @@ class TestCardRepr:
         model = fit_model()
         card = Card(model, model_diagram=False, template=None)
         result = meth(card)
-        expected = textwrap.dedent(
-            """
+        expected = textwrap.dedent("""
         Card(
           model=LinearRegression(),
         )
-        """
-        ).strip()
+        """).strip()
         assert result == expected
 
     @pytest.mark.parametrize("meth", [repr, str])

--- a/skops/io/_general.py
+++ b/skops/io/_general.py
@@ -191,7 +191,7 @@ class TupleNode(Node):
         f = getattr(t, "_fields", None)
         if not isinstance(f, tuple):
             return False
-        return all(type(n) == str for n in f)
+        return all(isinstance(n, str) for n in f)
 
 
 def function_get_state(obj: Any, save_context: SaveContext) -> dict[str, Any]:


### PR DESCRIPTION
This replaces flake8 and isort with ruff, which is much faster, updates linter versions, and fixes issues due to the version upgrades and using ruff.

