### PR TITLE
CI move to pypi's trusted publisher workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,11 @@ jobs:
   publish:
 
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: publish-pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -36,14 +41,9 @@ jobs:
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
       if: ${{ github.event.inputs.pypi_repo == 'testpypi' }}
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.10
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
       if: ${{ github.event.inputs.pypi_repo == 'pypi' }}


### PR DESCRIPTION
PyPi is moving to trusted publisher model, which I've configured for our repo, and needs some changes on the workflow. This would create a short lived token for the task.

It's now also strongly recommended that deployments use a separate environment on github, and I've configured that as well.

This PR can only be tested once merged, so I'm going to merge it to see how it behaves and if it works.