### PR TITLE
Space creator on `main` only

### DIFF
--- a/.github/workflows/deploy-model-card-creator.yml
+++ b/.github/workflows/deploy-model-card-creator.yml
@@ -2,7 +2,6 @@ name: Deploy-Space-Creator
 
 on:
   - push
-  - pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/deploy-model-card-creator.yml
+++ b/.github/workflows/deploy-model-card-creator.yml
@@ -2,6 +2,7 @@ name: Deploy-Space-Creator
 
 on:
   - push
+  - pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Space creator uses a token, and now tokens need to be secret. This makes it run only on `main` and not PRs. Also updated the token secret.

fixes https://github.com/skops-dev/skops/issues/364