### PR TITLE
ENH support types with a safe __reduce__

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -200,11 +200,6 @@ class TableSection(Section):
             raise ValueError("Trying to add table with no columns")
 
     def format(self) -> str:
-        if self._is_pandas_df:
-            pass  # type: ignore
-        else:
-            self.table.keys()
-
         table = PrettyTable()
         table.set_style(TableStyle.MARKDOWN)
         for key, values in self.table.items():

--- a/skops/io/_audit.py
+++ b/skops/io/_audit.py
@@ -362,7 +362,8 @@ def get_tree(
             type_name = f"{state['__module__']}.{state['__class__']}"
             raise TypeError(
                 f" Can't find loader {state['__loader__']} for type {type_name} and "
-                f"protocol {protocol}."
+                f"protocol {protocol}. You might need to update skops to load this "
+                "file."
             )
 
     loaded_tree = node_cls(state, load_context, trusted=trusted)

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -6,6 +6,7 @@ import operator
 import sys
 import warnings
 from collections import Counter, OrderedDict, defaultdict
+from datetime import datetime
 from functools import partial, wraps
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -1119,3 +1120,17 @@ def test_dictionary(cls):
     loaded_obj = loads(dumps(obj))
     assert obj == loaded_obj
     assert type(obj) is cls
+
+
+def test_datetime():
+    obj = datetime.now()
+    loaded_obj = loads(dumps(obj), trusted=[datetime])
+    assert obj == loaded_obj
+    assert type(obj) is datetime
+
+
+def test_slice():
+    obj = slice(1, 2, 3)
+    loaded_obj = loads(dumps(obj))
+    assert obj == loaded_obj
+    assert type(obj) is slice


### PR DESCRIPTION
Fixes https://github.com/skops-dev/skops/issues/464

Sometimes the output of `__reduce__` is of the form `(type, (constructor_args,)` where `type` is the same as the `type(obj)`. In such cases, we can consider loading them _safe_. We still fail if the given type is not _trusted_, but there's no danger of loading those objects since we want to load them anyway. We would be calling their `__new__` and `__setstate__` otherwise.

This adds supports to many other types such as `datetime` and `slice`.