### PR TITLE
MNT Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+| Version       | Supported          |
+| ------------- | ------------------ |
+| 0.11          | :white_check_mark: |
+| < 0.11        | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a new [GitHub security
+advisory](https://github.com/skops-dev/skops/security/advisories/new).


### PR DESCRIPTION
0.11.0 is the [last version on PyPI](https://pypi.org/project/skops/).

GitHub security advisory has already been enabled since I can use this URL: https://github.com/skops-dev/skops/security/advisories/new