### PR TITLE
FIX use rich.tree instead of rich.print

### DIFF
--- a/skops/conftest.py
+++ b/skops/conftest.py
@@ -50,7 +50,7 @@ def rich_not_installed():
     orig_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):
-        if name == "rich":
+        if name == "rich" or name.startswith("rich."):
             raise ImportError
         return orig_import(name, *args, **kwargs)
 

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -165,6 +165,10 @@ def pretty_print_tree(nodes_iter, show, **kwargs):
                 print(f"{node.key}: {label}")
                 continue
 
+            # Level diff of -1 means that this node is a child of the previous node.
+            # E.g. if the current level if 4 and the previous level was 3, the
+            # current node is a child node of the previous one. Since the prefix for
+            # a child node was already added, there is nothing more left to do.
             for _ in range(level_diff + 1):
                 # This loop is entered if the current node is at the same level as,
                 # or higher than, the previous node. This means the prefix has to be

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -165,8 +165,12 @@ def pretty_print_tree(nodes_iter, show, **kwargs):
                 print(f"{node.key}: {label}")
                 continue
 
-            # Update prefix based on level difference
             for _ in range(level_diff + 1):
+                # This loop is entered if the current node is at the same level as,
+                # or higher than, the previous node. This means the prefix has to be
+                # truncated according to the level difference. E.g. if the current
+                # level is 2 and previous level was 3, it means that we should move
+                # up 2 layers of nesting, therefore, we trunce 3-2+1 = 2 times.
                 prefix = prefix[:-4]
 
             print(prefix, end="")

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -141,8 +141,9 @@ def _traverse_tree(nodes_iter, show, **kwargs):
 
 def pretty_print_tree(nodes_iter, show, **kwargs):
     try:
-        from rich.tree import Tree
         from rich.console import Console
+        from rich.tree import Tree
+
         console = Console()
 
         for node, label, level_diff, is_first_node in _traverse_tree(nodes_iter, show):

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -139,7 +139,11 @@ def _traverse_tree(nodes_iter, show, **kwargs):
         prev_level = node.level
 
 
-def pretty_print_tree(nodes_iter, show, **kwargs):
+def pretty_print_tree(
+    nodes_iter: Iterator[NodeInfo],
+    show: Literal["all", "untrusted", "trusted"],
+    **kwargs: Any,
+) -> None:
     try:
         from rich.console import Console
         from rich.tree import Tree

--- a/skops/io/_visualize.py
+++ b/skops/io/_visualize.py
@@ -101,11 +101,11 @@ def _get_node_label(
     # colorize if so desired and if rich is installed
     if use_colors:
         if node.is_safe:
-            style = f"bold {color_safe}"
+            style = f"{color_safe}"
         elif node.is_self_safe:
-            style = f"bold {color_child_unsafe}"
+            style = f"{color_child_unsafe}"
         else:
-            style = f"bold {color_unsafe}"
+            style = f"{color_unsafe}"
         node_val = f"[{style}]{node_val}[/{style}]"
 
     return node_val
@@ -146,7 +146,9 @@ def pretty_print_tree(nodes_iter, show, **kwargs):
 
         console = Console()
 
-        for node, label, level_diff, is_first_node in _traverse_tree(nodes_iter, show):
+        for node, label, level_diff, is_first_node in _traverse_tree(
+            nodes_iter, show, **kwargs
+        ):
             if is_first_node:
                 tree = Tree(f"{node.key}: {label}", guide_style="gray50")
                 trees = {0: tree}
@@ -161,7 +163,9 @@ def pretty_print_tree(nodes_iter, show, **kwargs):
 
     except ImportError:
         prefix = ""
-        for node, label, level_diff, is_first_node in _traverse_tree(nodes_iter, show):
+        for node, label, level_diff, is_first_node in _traverse_tree(
+            nodes_iter, show, **kwargs
+        ):
             if is_first_node:
                 print(f"{node.key}: {label}")
                 continue

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -19,6 +19,18 @@ import skops.io as sio
 from skops.io import get_untrusted_types
 
 
+def get_Tree_str(tree):
+    """Get the string representation of a tree."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    with StringIO() as output:
+        console = Console(file=output)
+        console.print(tree)
+        return output.getvalue()
+
+
 class TestVisualizeTree:
     @pytest.fixture
     def simple(self):
@@ -177,7 +189,7 @@ class TestVisualizeTree:
         # Colors are not recorded by capsys, so we cannot use it and must mock
         # printing
         mock_print = Mock()
-        with patch("rich.print", mock_print):
+        with patch("rich.console.Console.print", mock_print):
             sio.visualize(
                 file,
                 color_safe="black",
@@ -188,15 +200,13 @@ class TestVisualizeTree:
         mock_print.assert_called()
 
         calls = mock_print.call_args_list
+        tree_repr = get_Tree_str(calls[0].args[0])
         # The root node is indirectly unsafe through child
-        assert (
-            calls[0].args[0]
-            == "root: [orange3]sklearn.preprocessing._data.MinMaxScaler"
-        )
+        assert "root: [orange3]sklearn.preprocessing._data.MinMaxScaler" in tree_repr
         # 'feature_range' is safe
-        assert calls[6].args[0] == " feature_range: [black]builtins.tuple"
+        assert " feature_range: [black]builtins.tuple" in tree_repr
         # 'copy' is unsafe
-        assert calls[15].args[0] == " copy: [cyan]test_visualize.UnsafeType [UNSAFE]"
+        assert " copy: [cyan]test_visualize.UnsafeType [UNSAFE]" in tree_repr
 
     @pytest.mark.usefixtures("rich_not_installed")
     def test_no_colors_if_rich_not_installed(self, simple):
@@ -231,7 +241,7 @@ class TestVisualizeTree:
         # don't use capsys, because it wouldn't capture the colors, thus need to
         # use mock
         mock_print = Mock()
-        with patch("rich.print", mock_print):
+        with patch("rich.console.Console.print", mock_print):
             sio.visualize(
                 file,
                 color_safe="black",
@@ -245,7 +255,7 @@ class TestVisualizeTree:
         colors = ("black", "cyan", "orange3")
         for call in mock_print.call_args_list:
             for color in colors:
-                assert color not in call.args[0]
+                assert color not in get_Tree_str(call.args[0])
 
     def test_from_file(self, simple, tmp_path, capsys):
         f_name = tmp_path / "estimator.skops"

--- a/skops/io/tests/test_visualize.py
+++ b/skops/io/tests/test_visualize.py
@@ -24,7 +24,9 @@ def get_Tree_str(tree):
     from rich.console import Console
     from rich.text import Text
 
-    console = Console()
+    # force the color system to check that we have the right colors across
+    # platforms and terminals
+    console = Console(force_terminal=True, color_system="truecolor")
     with console.capture() as capture:
         console.print(tree)
     text = Text.from_ansi(capture.get())
@@ -202,14 +204,14 @@ class TestVisualizeTree:
         calls = mock_print.call_args_list
         tree_repr = get_Tree_str(calls[0].args[0])
         # The root node is indirectly unsafe through child
-        # orange3 is color(5)
-        assert "root: [color(5)]sklearn.preprocessing._data.MinMaxScaler" in tree_repr
+        # orange3 is color(172)
+        assert "root: [color(172)]sklearn.preprocessing._data.MinMaxScaler" in tree_repr
         # 'feature_range' is safe
-        # black is color(6)
-        assert "feature_range: [color(6)]builtins.tuple" in tree_repr
+        # black is color(0)
+        assert "feature_range: [color(0)]builtins.tuple" in tree_repr
         # 'copy' is unsafe
-        # cyan is color(214)
-        assert "copy: [color(214)]test_visualize.UnsafeType [UNSAFE]" in tree_repr
+        # cyan is color(6)
+        assert "copy: [color(6)]test_visualize.UnsafeType [UNSAFE]" in tree_repr
 
     @pytest.mark.usefixtures("rich_not_installed")
     def test_no_colors_if_rich_not_installed(self, simple):


### PR DESCRIPTION
This PR fixes the `rich` tree visualization.

It also using some colorblind color scheme: cyan / orange1 / magenta