### PR TITLE
ENH: Adding is_trusted function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ node_modules
 
 exports
 trash
+
+#spyder
+.spyproject

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -231,7 +231,7 @@ mean you can just call `sio.load(<file>,
 trusted=get_untrusted_types(file=<file>))` on this object -- only pass the
 types you really trust to the ``trusted`` argument.
 
-Supported libraries
+Supported/Trusted libraries
 -------------------
 
 Skops intends to support all of **scikit-learn**, that is, not only its

--- a/skops/io/__init__.py
+++ b/skops/io/__init__.py
@@ -1,4 +1,5 @@
-from ._persist import dump, dumps, get_untrusted_types, load, loads
+from ._persist import dump, dumps, get_untrusted_types, load, loads, is_trusted
 from ._visualize import visualize
 
-__all__ = ["dumps", "load", "loads", "dump", "get_untrusted_types", "visualize"]
+__all__ = ["dumps", "load", "loads", "dump", "get_untrusted_types", 
+           "visualize","is_trusted"]


### PR DESCRIPTION
Adding functionality to determine if datatype is trusted in the skops framework.

Intended to help users determine what they are able to save safely so that a model can be loaded without the need to okay/verify untrusted datatypes.

#### Reference Issues/PRs

No references.

#### What does this implement/fix? Explain your changes.

This is meant to add simple functionality to determine if types are trusted within skops. The function is meant to help users identify what they can save within skops so that files can be loaded without the need to use the ```trusted``` keyword. This will hopefully help streamline the loading of ```.skops``` files.


#### Any other comments?

Also put a small change in ```skops\docs\persistence.rst``` to help clarify that *Supported* libraries also meant *Trusted* libraries. When reading the documentation it was unclear exactly what was *Trusted*. 

This is my first pull request in a larger project. I've tried to make sure I've followed the rules as layed out in the Contributing guidelines. Apologies if I have not!


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy.

Thanks for contributing!
-->
