### PR TITLE
ENH harden Card by adding a flag to allow/disallow insecure pickle loading

### DIFF
--- a/skops/card/_model_card.py
+++ b/skops/card/_model_card.py
@@ -227,7 +227,9 @@ class TableSection(Section):
         return f"{self.__class__.__name__}({nrows}x{ncols})"
 
 
-def _load_model(model: Any, trusted=False, allow_pickle: bool=False) -> Any:
+def _load_model(
+    model: Any, trusted: Optional[Sequence[str]] = None, allow_pickle: bool = False
+) -> Any:
     """Return a model instance.
 
     Loads the model if provided a file path, if already a model instance return
@@ -238,7 +240,7 @@ def _load_model(model: Any, trusted=False, allow_pickle: bool=False) -> Any:
     model : pathlib.Path, str, or sklearn estimator
         Path/str or the actual model instance. if a Path or str, loads the model.
 
-    trusted : bool, default=False
+    trusted: list of str, default=None
         Passed to :func:`skops.io.load` if the model is a file path and it's
         a `skops` file.
 
@@ -327,7 +329,7 @@ class Card:
         not work, e.g. :meth:`Card.add_metrics`, since it's not clear where to
         put the metrics when there is no template or a custom template.
 
-    trusted: bool, default=False
+    trusted: list of str, default=None
         Passed to :func:`skops.io.load` if the model is a file path and it's
         a `skops` file.
 

--- a/skops/card/tests/test_card.py
+++ b/skops/card/tests/test_card.py
@@ -82,12 +82,20 @@ def test_load_model(suffix):
     _, save_file = save_model_to_file(model0, suffix)
     if suffix == ".skops":
         untrusted_types = get_untrusted_types(file=save_file)
+        allow_pickle = False
     else:
         untrusted_types = None
-    loaded_model_str = _load_model(save_file, trusted=untrusted_types)
+        allow_pickle = True
+    loaded_model_str = _load_model(
+        save_file, trusted=untrusted_types, allow_pickle=allow_pickle
+    )
     save_file_path = Path(save_file)
-    loaded_model_path = _load_model(save_file_path, trusted=untrusted_types)
-    loaded_model_instance = _load_model(model0, trusted=untrusted_types)
+    loaded_model_path = _load_model(
+        save_file_path, trusted=untrusted_types, allow_pickle=allow_pickle
+    )
+    loaded_model_instance = _load_model(
+        model0, trusted=untrusted_types, allow_pickle=allow_pickle
+    )
 
     assert loaded_model_str.param_1 == 10
     assert loaded_model_path.param_1 == 10
@@ -166,7 +174,9 @@ def test_model_caching(skops_model_card, iris_skops_file, destination_path):
 
     new_model = MyClassifier(param_1=10)
     # mock _load_model, it still loads the model but we can track call count
-    mock_load_model = mock.Mock(side_effect=load)
+    mock_load_model = mock.Mock(
+        side_effect=lambda path, trusted, _: load(path, trusted=trusted)
+    )
     card = Card(iris_skops_file, trusted=[MyClassifier])
     with mock.patch("skops.card._model_card._load_model", mock_load_model):
         model1 = card.get_model()
@@ -1133,7 +1143,7 @@ class TestCardModelAttributeIsPath:
         if suffix == ".skops":
             card = Card(model=path, trusted=get_untrusted_types(file=path))
         else:
-            card = Card(model=path)
+            card = Card(model=path, allow_pickle=True)
         return card
 
     @pytest.mark.parametrize("meth", [repr, str])


### PR DESCRIPTION
The PR introduces additional hardening for models loaded through `Card`.
If the model is in an insecure pickle format, it is now required to explicitly set a flag during `Card` object creation to allow the operation.

@adrinjalali 
