### PR TITLE
MAINT: fix the way to point to the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+MIT License (MIT)
 
 Copyright (C) 2021 Hugging Face Inc.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+license-files = ["LICENSE"]
+
 [tool.hatch.version]
 path = "skops/__init__.py"
 
@@ -35,7 +38,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-license = {file = "LICENSE"}
 dependencies = [
     "numpy>=1.25.0",
     "scipy>=1.10.0",


### PR DESCRIPTION
When using `pixi-build` to create the conda package, the current way to specify the license does not work because it makes the parsing failed with an unrecognized type of license.

Looking at the documentation, i.e. https://hatch.pypa.io/1.13/config/metadata/#spdx-expression, `license` should be a string mentioning the type of license. Here, we want to point to a license file and we should be using `license-files` instead.