### PR TITLE
CI Cleanup pytest warning/errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ filterwarnings = [
     "error::FutureWarning",
     # comes from fairlearn
     "ignore:DataFrameGroupBy.apply operated on the grouping columns.:DeprecationWarning",
+    # sklearn1.8 deprecates this class
+    "ignore:Class PassiveAggressiveClassifier is deprecated:FutureWarning",
 ]
 addopts = "--cov=skops --cov-report=term-missing --doctest-modules"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,30 +70,8 @@ doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 filterwarnings = [
     "error::DeprecationWarning",
     "error::FutureWarning",
-    # TODO: remove when no longer supporting sklearn v1.0
-    # numpy and scipy deprecation warnings in sklearn:
-    'ignore:\n\n  \`numpy.distutils\` is deprecated since NumPy:DeprecationWarning',
-    # https://github.com/scikit-learn/scikit-learn/issues/24080
-    "ignore:The \\'sym_pos\\' keyword is deprecated and should be replaced:DeprecationWarning",
-    # https://github.com/scikit-learn/scikit-learn/pull/23633
-    "ignore:Unlike other reduction functions:FutureWarning",
-    # https://github.com/scikit-learn/scikit-learn/pull/25157
-    "ignore:\\w+ is deprecated. Use files\\(\\) instead:DeprecationWarning",
     # comes from fairlearn
-    "ignore:DataFrame.applymap has been deprecated. Use DataFrame.map instead:FutureWarning",
     "ignore:DataFrameGroupBy.apply operated on the grouping columns.:DeprecationWarning",
-    # Ignore Pandas 2.2 warning on PyArrow. It might be reverted in a later release.
-    "ignore:\\s*Pyarrow will become a required dependency of pandas.*:DeprecationWarning",
-    # LightGBM sklearn 1.6 deprecation warning, fixed in the next release
-    "ignore:'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.:FutureWarning",
-    # RandomForestQuantileRegressor tags deprecation warning in sklearn 1.7
-    "ignore:The RandomForestQuantileRegressor or classes from which it inherits use `_get_tags` and `_more_tags`:FutureWarning",
-    # ExtraTreesQuantileRegressor tags deprecation warning in sklearn 1.7
-    "ignore:The ExtraTreesQuantileRegressor or classes from which it inherits use `_get_tags` and `_more_tags`:FutureWarning",
-    # BaseEstimator._validate_data deprecation warning in sklearn 1.6 #TODO can be removed when a new release of quantile-forest is out
-    "ignore:`BaseEstimator._validate_data` is deprecated in 1.6 and will be removed in 1.7:FutureWarning",
-    # This comes from matplotlib somehow
-    "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning",
 ]
 addopts = "--cov=skops --cov-report=term-missing --doctest-modules"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ filterwarnings = [
     "ignore:DataFrameGroupBy.apply operated on the grouping columns.:DeprecationWarning",
     # sklearn1.8 deprecates this class
     "ignore:Class PassiveAggressiveClassifier is deprecated:FutureWarning",
+    "ignore:Class PassiveAggressiveRegressor is deprecated:FutureWarning",
 ]
 addopts = "--cov=skops --cov-report=term-missing --doctest-modules"
 

--- a/skops/io/tests/test_persist.py
+++ b/skops/io/tests/test_persist.py
@@ -148,6 +148,16 @@ def _tested_estimators(type_filter=None):
                     # default solver will be "highs" from scikit-learn >= 1.4.0.
                     # https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.QuantileRegressor.html
                     estimators = construct_instances(partial(Estimator, solver="highs"))
+                elif name == "SparseCoder":
+                    dictionary = np.random.randint(-2, 3, size=(5, N_FEATURES)).astype(
+                        float
+                    )
+                    estimators = [
+                        SparseCoder(
+                            dictionary=dictionary,
+                            transform_algorithm="lasso_lars",
+                        )
+                    ]
                 else:
                     estimators = construct_instances(Estimator)
 
@@ -245,12 +255,6 @@ def _tested_estimators(type_filter=None):
         LogisticRegression(random_state=0, solver="liblinear"),
         {"C": [1, 2, 3, 4, 5]},
         n_iter=3,
-    )
-
-    dictionary = np.random.randint(-2, 3, size=(5, N_FEATURES)).astype(float)
-    yield SparseCoder(
-        dictionary=dictionary,
-        transform_algorithm="lasso_lars",
     )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/skops-dev/skops/blob/main/CONTRIBUTING.rst
This guideline contains crucial information for your PR to be merged, such as setting up
development environment or linting your code.
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes, partially fixes) to create link to the issues
or pull requests you resolved, so that they will automatically be closed when
your pull request is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

`None`

#### What does this implement/fix? Explain your changes.

- [x] Remove warnings that no longer need to be ignored in CI tests
- [x] Fix the `FutureWarning: Class PassiveAggressiveClassifier is deprecated;` error in scikit-learn nightly version CI runs ([e.g.](https://github.com/skops-dev/skops/actions/runs/18142342972/job/51881654657?pr=494))
- [x] Fix the `FutureWarning: Class PassiveAggressiveRegressor is deprecated;`
- ~~Figure out why the `SparseCoder.dictionary.shape` becomes `(5, 3)` even though it is passed as `(5, 20)` in the sklearn-nightly version~~
- [x] Write custom test for `SparseCoder` as it is being tested now in `sklearn-nightly`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy.
Thanks for contributing!
-->
I'm looking into how to ignore the `PassiveAggressiveClassifier` warning. I am trying to do it through `pyproject.toml`'s `filterwarnings`. I tried the *options* below but nothing works so far :/ I asked on pytest's discord for help. But if someone knows, definitely let me know :pray: 

<details>
<summary>tried options</summary>

```
"ignore:Class PassiveAggressiveClassifier is deprecated:FutureWarning:sklearn.linear_model._passive_aggressive",
"ignore:FutureWarning: Class PassiveAggressiveClassifier is deprecated",
"ignore:.*PassiveAggressiveClassifier.*:FutureWarning",
"ignore::FutureWarning:sklearn.linear_model._passive_aggressive",
"ignore:Class PassiveAggressiveClassifier is deprecated:FutureWarning",
"ignore:Class PassiveAggressiveClassifier is deprecated; this is deprecated in version 1.8 and will be removed in 1.10. Use `SGDClassifier(loss='hinge', penalty=None, learning_rate='pa1', eta0=1.0)` instead.:FutureWarning",
"ignore:Class PassiveAggressiveClassifier is deprecated*:FutureWarning",
"ignore:Class PassiveAggressiveClassifier is deprecated.*:FutureWarning",
"ignore:Class PassiveAggressiveClassifier is deprecated;:FutureWarning",
"ignore:sklearn.linear_model.PassiveAggressiveClassifier:FutureWarning",
"ignore:FutureWarning:sklearn.linear_model.PassiveAggressiveClassifier",
"ignore::FutureWarning:sklearn.linear_model.PassiveAggressiveClassifier",
"ignore:Class PassiveAggressiveClassifier is deprecated:FutureWarning", (from adrinjalali)
"default:Class PassiveAggressiveClassifier is deprecated:FutureWarning",
```

</details>


